### PR TITLE
feat(mcp): analysis-backed doc generation in MCP mode

### DIFF
--- a/scripts/mcp-tools-list.js
+++ b/scripts/mcp-tools-list.js
@@ -1,0 +1,65 @@
+// Minimal MCP stdio client to request tools/list
+import { spawn } from 'node:child_process';
+
+function encodeMessage(obj) {
+  const body = Buffer.from(JSON.stringify(obj), 'utf8');
+  const header = Buffer.from(`Content-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n`, 'utf8');
+  return Buffer.concat([header, body]);
+}
+
+function decodeMessages(buffer) {
+  const messages = [];
+  let buf = buffer;
+  while (true) {
+    const headerEnd = buf.indexOf('\r\n\r\n');
+    if (headerEnd === -1) break;
+    const header = buf.slice(0, headerEnd).toString('utf8');
+    const match = header.match(/Content-Length:\s*(\d+)/i);
+    if (!match) break;
+    const length = parseInt(match[1], 10);
+    const start = headerEnd + 4;
+    const end = start + length;
+    if (buf.length < end) break;
+    const body = buf.slice(start, end).toString('utf8');
+    try { messages.push(JSON.parse(body)); } catch {}
+    buf = buf.slice(end);
+  }
+  return { messages, rest: buf };
+}
+
+const child = spawn(process.execPath, ['mcp-server.js'], { stdio: ['pipe', 'pipe', 'inherit'] });
+
+let outBuf = Buffer.alloc(0);
+let initialized = false;
+let initReplied = false;
+child.stdout.on('data', (chunk) => {
+  outBuf = Buffer.concat([outBuf, chunk]);
+  const { messages, rest } = decodeMessages(outBuf);
+  outBuf = rest;
+  for (const m of messages) {
+    // console.log('<<', JSON.stringify(m));
+    if (!initReplied && m.id === 1) {
+      initReplied = true;
+      // Send initialized notification then request tools/list
+      const initializedNote = { jsonrpc: '2.0', method: 'notifications/initialized', params: {} };
+      child.stdin.write(encodeMessage(initializedNote));
+      const listReq = { jsonrpc: '2.0', id: 2, method: 'tools/list' };
+      child.stdin.write(encodeMessage(listReq));
+    } else if (m.id === 2) {
+      console.log('Tools:', m.result?.tools?.map(t => t.name).join(', '));
+      try { child.kill('SIGTERM'); } catch {}
+    }
+  }
+});
+// Send initialize
+const initReq = {
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: {
+    protocolVersion: '2024-09-18',
+    capabilities: { tools: { list: true, call: true } },
+    clientInfo: { name: 'local-smoke-client', version: '0.0.1' }
+  }
+};
+child.stdin.write(encodeMessage(initReq));

--- a/scripts/smoke-mcp.js
+++ b/scripts/smoke-mcp.js
@@ -1,0 +1,32 @@
+// Simple smoke test: start mcp-server.js, wait briefly, then terminate
+import { spawn } from 'node:child_process';
+
+function runSmoke() {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, ['mcp-server.js'], {
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      try { child.kill('SIGTERM'); } catch {}
+      resolve({ ok: true, stdout, stderr, note: 'terminated after timeout' });
+    }, 700);
+
+    child.stdout.on('data', (d) => { stdout += d.toString(); });
+    child.stderr.on('data', (d) => { stderr += d.toString(); });
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      resolve({ ok: false, error: String(err), stdout, stderr });
+    });
+    child.on('exit', (code, signal) => {
+      clearTimeout(timer);
+      resolve({ ok: true, code, signal, stdout, stderr });
+    });
+  });
+}
+
+const res = await runSmoke();
+console.log(JSON.stringify(res, null, 2));
+

--- a/specGenerator.js
+++ b/specGenerator.js
@@ -1,0 +1,263 @@
+import { analyzeProject } from './documentGenerator.js';
+
+export async function generateRequirementsDocument(projectPath, featureName) {
+  const analysis = await analyzeProject(projectPath);
+  const desc = analysis.description || 'Feature requirements specification';
+  const obj = generateCoreObjective(analysis);
+  const acceptance = generateAcceptanceCriteria(analysis)
+    .map((c, i) => `${i + 1}. ${c}`)
+    .join('\n');
+
+  return `# Requirements Document
+
+## Introduction
+${featureName} - Requirements derived from codebase analysis.
+
+**Project**: ${analysis.name}  
+**Description**: ${desc}
+
+Generated on: ${new Date().toISOString()}
+
+## Functional Requirements
+
+### FR-1: Core Functionality
+**Objective:** ${obj}
+
+#### Acceptance Criteria
+${acceptance}
+
+### FR-2: Technology Integration
+**Objective:** Integrate with the detected technology stack
+
+#### Acceptance Criteria
+${generateTechRequirements(analysis).map((r, i) => `${i + 1}. ${r}`).join('\n')}
+
+### FR-3: Quality Standards
+**Objective:** Meet quality, testing, and review standards
+
+#### Acceptance Criteria
+${generateQualityRequirements(analysis).map((r, i) => `${i + 1}. ${r}`).join('\n')}
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- System SHALL respond within acceptable time limits
+- Memory usage SHALL remain within reasonable bounds
+
+### NFR-2: Reliability
+- System SHALL handle errors gracefully
+- System SHALL maintain data integrity
+
+### NFR-3: Maintainability
+- Code SHALL follow established conventions
+- System SHALL be well-documented
+`;
+}
+
+export async function generateDesignDocument(projectPath, featureName) {
+  const analysis = await analyzeProject(projectPath);
+  const arch = describeArchitecture(analysis);
+  const components = generateComponentList(analysis).map(c => `- **${c.name}**: ${c.description}`).join('\n');
+  const dataModels = generateDataModels(analysis).map(m => `- **${m}**: Data structure definition`).join('\n');
+  const techStack = generateDetailedTechStack(analysis);
+
+  return `# Technical Design Document
+
+## Project: ${featureName}
+
+**Project Name:** ${analysis.name}
+**Architecture:** ${analysis.architecture}
+**Language:** ${analysis.language}
+
+Generated on: ${new Date().toISOString()}
+
+## Architecture Overview
+
+### System Architecture
+${arch}
+
+### Key Components
+${components}
+
+### Data Models
+${dataModels}
+
+## Implementation Details
+
+### Technology Stack
+${techStack}
+
+### Dependencies
+${generateDependencySummary(analysis)}
+
+## Interface Specifications
+
+### Module Interfaces
+${generateModuleInterfaces(analysis)}
+
+## Configuration
+
+### Environment Variables
+${generateEnvVars(analysis)}
+
+### Build Configuration
+${generateBuildConfig(analysis)}
+`;
+}
+
+export async function generateTasksDocument(projectPath, featureName) {
+  const analysis = await analyzeProject(projectPath);
+  const tasks = generateImplementationTasks(analysis);
+
+  const section = (title, list) =>
+    list.map((task, idx) => `- [ ] ${idx + 1}. ${task.title}
+  ${task.subtasks.map(s => `  - ${s}`).join('\n')}
+  - _Requirements: ${task.requirements}_`).join('\n\n');
+
+  return `# Implementation Plan
+
+## Project: ${featureName}
+
+**Project Name:** ${analysis.name}
+**Detected Stack:** ${[analysis.language, analysis.framework || '', analysis.buildTool || ''].filter(Boolean).join(' / ')}
+
+Generated on: ${new Date().toISOString()}
+
+## Development Phase Tasks
+
+${section('Development', tasks.development)}
+
+## Integration Phase Tasks
+
+${section('Integration', tasks.integration)}
+
+## Quality & Testing Tasks
+
+${section('Quality', tasks.quality)}
+`;
+}
+
+// Helper functions
+function generateCoreObjective(analysis) {
+  if (analysis.dependencies?.includes('@modelcontextprotocol/sdk')) return 'Provide MCP tools for spec-driven development workflows';
+  if (analysis.framework === 'Express.js') return 'Expose REST endpoints and middleware for business logic';
+  if (analysis.framework === 'React') return 'Render interactive UI components with state management';
+  return 'Deliver feature-aligned functionality integrated with existing architecture';
+}
+
+function generateAcceptanceCriteria(analysis) {
+  const criteria = [
+    'WHEN invoked THEN it SHALL execute without runtime errors',
+    'IF input is invalid THEN it SHALL return meaningful errors',
+    'WHILE under typical load IT SHALL meet performance targets'
+  ];
+  if (analysis.testFramework) criteria.push('WHERE tests exist THEY SHALL pass with adequate coverage');
+  if (analysis.language === 'typescript') criteria.push('WHEN type-checking THEN no TypeScript errors SHALL occur');
+  return criteria;
+}
+
+function generateTechRequirements(analysis) {
+  const out = ['Integrate with existing build and run scripts'];
+  if (analysis.dependencies?.includes('@modelcontextprotocol/sdk')) out.push('Expose MCP-compliant tools over stdio');
+  if (analysis.buildTool) out.push(`Provide build artifacts using ${analysis.buildTool}`);
+  return out;
+}
+
+function generateQualityRequirements(analysis) {
+  const out = ['Follow project coding conventions', 'Apply error handling and logging'];
+  if (analysis.testFramework) out.push(`Include ${analysis.testFramework} tests for new code`);
+  return out;
+}
+
+function describeArchitecture(analysis) {
+  if (analysis.architecture === 'Domain-Driven Design (DDD)') return 'Layered DDD: Domain, Application, Infrastructure, Presentation';
+  if (analysis.architecture.includes('API')) return 'REST API with routing, middleware, services, and data access layers';
+  if (analysis.framework === 'MCP SDK') return 'MCP server exposing development tools via stdio protocol';
+  return analysis.architecture || 'Modular architecture with clear separation of concerns';
+}
+
+function generateComponentList(analysis) {
+  const comps = [];
+  if (analysis.framework === 'MCP SDK') {
+    comps.push({ name: 'MCPServer', description: 'Handles stdio transport and tool registry' });
+    comps.push({ name: 'ToolHandlers', description: 'Implement SDD tools (init, requirements, design, tasks, etc.)' });
+  }
+  if (analysis.architecture.includes('API')) {
+    comps.push({ name: 'Controllers', description: 'HTTP route handlers' });
+    comps.push({ name: 'Services', description: 'Business logic orchestration' });
+  }
+  if (comps.length === 0) comps.push({ name: 'CoreModule', description: 'Primary feature implementation module' });
+  return comps;
+}
+
+function generateDataModels(analysis) {
+  if (analysis.framework === 'MCP SDK') return ['Tool', 'Request', 'Response'];
+  if (analysis.architecture.includes('API')) return ['RequestDTO', 'ResponseDTO'];
+  return ['Entity', 'ValueObject'];
+}
+
+function generateDetailedTechStack(analysis) {
+  const parts = [];
+  parts.push(`- Runtime: ${analysis.language === 'typescript' ? 'Node.js (TypeScript)' : 'Node.js (JavaScript)'}`);
+  if (analysis.framework) parts.push(`- Framework: ${analysis.framework}`);
+  if (analysis.buildTool) parts.push(`- Build: ${analysis.buildTool}`);
+  if (analysis.testFramework) parts.push(`- Testing: ${analysis.testFramework}`);
+  return parts.join('\n');
+}
+
+function generateDependencySummary(analysis) {
+  const deps = (analysis.dependencies || []).slice(0, 10).map(d => `- ${d}`).join('\n');
+  const dev = (analysis.devDependencies || []).slice(0, 10).map(d => `- ${d}`).join('\n');
+  return `#### Production\n${deps || '- (none)'}\n\n#### Development\n${dev || '- (none)'}`;
+}
+
+function generateModuleInterfaces(analysis) {
+  if (analysis.framework === 'MCP SDK') {
+    return `- registerTool(name: string, handler: (args) => Promise<unknown>)\n- connect(transport): Promise<void>`;
+  }
+  if (analysis.architecture.includes('API')) {
+    return `- handle(request): Response\n- service.process(input): Result`;
+  }
+  return `- execute(input): Output`;
+}
+
+function generateEnvVars(analysis) {
+  const envs = ['NODE_ENV', 'LOG_LEVEL'];
+  if (analysis.framework === 'MCP SDK') envs.push('MCP_MODE');
+  return envs.map(e => `- ${e}`).join('\n');
+}
+
+function generateBuildConfig(analysis) {
+  if (analysis.buildTool) return `Use ${analysis.buildTool} to emit production artifacts`;
+  return 'Use npm scripts (build/test/lint) defined in package.json';
+}
+
+function generateImplementationTasks(analysis) {
+  const dev = [
+    { title: 'Set up project scaffolding', subtasks: ['Initialize directories', 'Configure scripts'], requirements: 'FR-1' },
+    { title: 'Implement core feature logic', subtasks: ['Add modules', 'Wire integrations'], requirements: 'FR-1' }
+  ];
+  const integ = [
+    { title: 'Integrate with stack', subtasks: ['Validate build', 'Run dev server'], requirements: 'FR-2' }
+  ];
+  const quality = [
+    { title: 'Add tests and quality checks', subtasks: ['Unit tests', 'Lint/typecheck', 'Quality review'], requirements: 'FR-3' }
+  ];
+
+  if (analysis.framework === 'MCP SDK') {
+    dev.unshift({ title: 'Expose MCP tools', subtasks: ['Register tools', 'Handle stdio transport'], requirements: 'FR-2' });
+  }
+  if (analysis.architecture.includes('API')) {
+    dev.unshift({ title: 'Add HTTP endpoints', subtasks: ['Define routes', 'Implement handlers'], requirements: 'FR-1' });
+  }
+
+  if (analysis.testFramework) {
+    quality[0].subtasks.unshift(`Set up ${analysis.testFramework}`);
+  }
+  if (analysis.language === 'typescript') {
+    quality[0].subtasks.push('Ensure type safety (tsc)');
+  }
+
+  return { development: dev, integration: integ, quality };
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -855,8 +855,16 @@ async function handleRequirementsSimplified(args: any) {
       }
     }
     
-    // Generate EARS-formatted requirements based on description
-    const requirementsContent = `# Requirements Document
+    // Generate analysis-backed requirements; fallback to template on error
+    let requirementsContent: string;
+    try {
+      const { generateRequirementsDocument } = await import('./utils/specGenerator.js');
+      requirementsContent = await generateRequirementsDocument(process.cwd(), featureName);
+    } catch (genErr) {
+      requirementsContent = `# Requirements Document
+
+<!-- Warning: Analysis-backed generation failed. Using fallback template. -->
+<!-- Error: ${(genErr as Error).message} -->
 
 ## Introduction
 ${generateIntroductionFromDescription(projectDescription)}
@@ -885,6 +893,7 @@ ${generateEARSRequirements(projectDescription).map((req, index) => `${index + 1}
 2. WHERE help is needed THE system SHALL provide clear documentation and guidance
 3. IF I make mistakes THEN the system SHALL provide helpful error messages and recovery options
 `;
+    }
 
     // Update spec.json with phase information
     const specDir = path.join(process.cwd(), '.kiro', 'specs', featureName);
@@ -967,106 +976,30 @@ async function handleDesignSimplified(args: any) {
       }
     }
     
-    // Generate design document based on requirements
-    const designContent = `# Technical Design Document
+    // Generate analysis-backed design
+    let designContent: string;
+    try {
+      const { generateDesignDocument } = await import('./utils/specGenerator.js');
+      designContent = await generateDesignDocument(process.cwd(), featureName);
+    } catch (genErr) {
+      // Fallback to previous template on error with warning header
+      designContent = `# Technical Design Document
+
+<!-- Warning: Analysis-backed generation failed. Using fallback template. -->
+<!-- Error: ${(genErr as Error).message} -->
 
 ## Overview
 This design document specifies the technical implementation approach for ${spec.feature_name}. 
 
 **Purpose**: ${projectDescription}
 
-**Goals**:
-- Deliver a robust and maintainable solution
-- Ensure scalability and performance
-- Follow established architectural patterns
-
-## Architecture
-
-### High-Level Architecture
-The system follows a modular architecture with clear separation of concerns:
-
-- **Input Layer**: Handles user input validation and processing
-- **Core Logic**: Implements business logic and rules
-- **Output Layer**: Manages results presentation and formatting
-- **Error Handling**: Provides comprehensive error management
-
 ### System Flow
-1. **Input Processing**: Validate and sanitize user input
-2. **Business Logic**: Execute core functionality 
-3. **Result Generation**: Process and format outputs
-4. **Error Management**: Handle exceptions and edge cases
-
-## Components and Interfaces
-
-### Core Components
-
-#### Input Processor
-- **Responsibility**: Input validation and sanitization
-- **Interface**: 
-  - \`validateInput(data: InputData): ValidationResult\`
-  - \`sanitizeInput(data: InputData): CleanData\`
-
-#### Business Logic Engine  
-- **Responsibility**: Core functionality implementation
-- **Interface**:
-  - \`processRequest(input: CleanData): ProcessingResult\`
-  - \`handleBusinessRules(data: CleanData): RuleResult\`
-
-#### Output Formatter
-- **Responsibility**: Result formatting and presentation
-- **Interface**:
-  - \`formatResult(result: ProcessingResult): FormattedOutput\`
-  - \`handleError(error: Error): ErrorResponse\`
-
-## Data Models
-
-### Input Data Model
-\`\`\`typescript
-interface InputData {
-  // Input structure based on requirements
-  payload: unknown;
-  metadata: Record<string, unknown>;
-}
-\`\`\`
-
-### Processing Result Model
-\`\`\`typescript
-interface ProcessingResult {
-  success: boolean;
-  data: unknown;
-  metadata: ResultMetadata;
-}
-\`\`\`
-
-## Error Handling
-
-### Error Categories
-- **Validation Errors**: Invalid input format or content
-- **Processing Errors**: Failures during business logic execution
-- **System Errors**: Infrastructure or dependency failures
-
-### Error Response Strategy
-- Clear error messages for user-facing issues
-- Detailed logging for system debugging
-- Graceful degradation where possible
-
-## Testing Strategy
-
-### Unit Tests
-- Input validation functions
-- Business logic components
-- Output formatting utilities
-
-### Integration Tests
-- End-to-end workflow validation
-- Error handling scenarios
-- Performance under load
-
-### Quality Assurance
-- Code coverage requirements
-- Performance benchmarks
-- Security validation
+1. Input Processing
+2. Business Logic
+3. Result Generation
+4. Error Management
 `;
+    }
 
     // Update spec.json with phase information
     const specDir = path.join(process.cwd(), '.kiro', 'specs', featureName);
@@ -1141,80 +1074,24 @@ async function handleTasksSimplified(args: any) {
       throw new Error(`Design must be generated before tasks. Run sdd-design ${featureName} first.`);
     }
     
-    // Generate implementation tasks following kiro format
-    const tasksContent = `# Implementation Plan
+    // Generate analysis-backed tasks
+    let tasksContent: string;
+    try {
+      const { generateTasksDocument } = await import('./utils/specGenerator.js');
+      tasksContent = await generateTasksDocument(process.cwd(), featureName);
+    } catch (genErr) {
+      tasksContent = `# Implementation Plan
+
+<!-- Warning: Analysis-backed generation failed. Using fallback template. -->
+<!-- Error: ${(genErr as Error).message} -->
 
 - [ ] 1. Set up project foundation and infrastructure
-- [ ] 1.1 Initialize project structure and configuration
-  - Create directory structure as per design
-  - Set up build configuration and tooling
-  - Initialize version control and documentation
-  - _Requirements: All requirements need foundational setup_
-
-- [ ] 1.2 Implement core infrastructure components
-  - Set up error handling framework
-  - Create logging and monitoring utilities
-  - Establish configuration management
-  - _Requirements: System quality requirements_
-
 - [ ] 2. Implement core functionality
-- [ ] 2.1 Develop input processing components
-  - Build input validation system
-  - Implement data sanitization logic
-  - Create input parsing utilities
-  - _Requirements: 1.1, 1.2_
-
-- [ ] 2.2 Build business logic engine
-  - Implement core processing algorithms
-  - Create business rule validation
-  - Develop result generation logic
-  - _Requirements: 1.1, 1.3_
-
-- [ ] 2.3 Create output formatting system
-  - Build result formatting utilities
-  - Implement response generation
-  - Create output validation
-  - _Requirements: 1.2, 1.3_
-
 - [ ] 3. Implement error handling and validation
-- [ ] 3.1 Build comprehensive error management
-  - Create error classification system
-  - Implement error recovery mechanisms
-  - Build error logging and reporting
-  - _Requirements: 2.1, 2.2_
-
-- [ ] 3.2 Add input/output validation
-  - Implement schema validation
-  - Create boundary condition checks
-  - Add security validation layers
-  - _Requirements: 2.1, 3.1_
-
 - [ ] 4. Develop testing and quality assurance
-- [ ] 4.1 Create unit test suite
-  - Test input processing components
-  - Test business logic functions
-  - Test output formatting utilities
-  - _Requirements: All functional requirements_
-
-- [ ] 4.2 Build integration test framework
-  - Test end-to-end workflows
-  - Test error handling scenarios
-  - Test performance benchmarks
-  - _Requirements: 2.1, 2.2, 2.3_
-
 - [ ] 5. Finalize implementation and deployment
-- [ ] 5.1 Integrate all components
-  - Wire together all system components
-  - Implement final error handling
-  - Add performance optimizations
-  - _Requirements: All requirements integration_
-
-- [ ] 5.2 Prepare for deployment
-  - Create deployment configuration
-  - Add production monitoring
-  - Finalize documentation
-  - _Requirements: System quality and deployment_
 `;
+    }
 
     // Update spec.json with phase information
     const specDir = path.join(process.cwd(), '.kiro', 'specs', featureName);

--- a/src/utils/specGenerator.ts
+++ b/src/utils/specGenerator.ts
@@ -1,0 +1,264 @@
+import { analyzeProject } from './documentGenerator.js';
+
+export async function generateRequirementsDocument(projectPath: string, featureName: string): Promise<string> {
+  const analysis = await analyzeProject(projectPath);
+  const desc = analysis.description || 'Feature requirements specification';
+  const obj = generateCoreObjective(analysis);
+  const acceptance = generateAcceptanceCriteria(analysis)
+    .map((c, i) => `${i + 1}. ${c}`)
+    .join('\n');
+
+  return `# Requirements Document
+
+## Introduction
+${featureName} - Requirements derived from codebase analysis.
+
+**Project**: ${analysis.name}  
+**Description**: ${desc}
+
+Generated on: ${new Date().toISOString()}
+
+## Functional Requirements
+
+### FR-1: Core Functionality
+**Objective:** ${obj}
+
+#### Acceptance Criteria
+${acceptance}
+
+### FR-2: Technology Integration
+**Objective:** Integrate with the detected technology stack
+
+#### Acceptance Criteria
+${generateTechRequirements(analysis).map((r, i) => `${i + 1}. ${r}`).join('\n')}
+
+### FR-3: Quality Standards
+**Objective:** Meet quality, testing, and review standards
+
+#### Acceptance Criteria
+${generateQualityRequirements(analysis).map((r, i) => `${i + 1}. ${r}`).join('\n')}
+
+## Non-Functional Requirements
+
+### NFR-1: Performance
+- System SHALL respond within acceptable time limits
+- Memory usage SHALL remain within reasonable bounds
+
+### NFR-2: Reliability
+- System SHALL handle errors gracefully
+- System SHALL maintain data integrity
+
+### NFR-3: Maintainability
+- Code SHALL follow established conventions
+- System SHALL be well-documented
+`;
+}
+
+export async function generateDesignDocument(projectPath: string, featureName: string): Promise<string> {
+  const analysis = await analyzeProject(projectPath);
+  const arch = describeArchitecture(analysis);
+  const components = generateComponentList(analysis).map(c => `- **${c.name}**: ${c.description}`).join('\n');
+  const dataModels = generateDataModels(analysis).map(m => `- **${m}**: Data structure definition`).join('\n');
+  const techStack = generateDetailedTechStack(analysis);
+
+  return `# Technical Design Document
+
+## Project: ${featureName}
+
+**Project Name:** ${analysis.name}
+**Architecture:** ${analysis.architecture}
+**Language:** ${analysis.language}
+
+Generated on: ${new Date().toISOString()}
+
+## Architecture Overview
+
+### System Architecture
+${arch}
+
+### Key Components
+${components}
+
+### Data Models
+${dataModels}
+
+## Implementation Details
+
+### Technology Stack
+${techStack}
+
+### Dependencies
+${generateDependencySummary(analysis)}
+
+## Interface Specifications
+
+### Module Interfaces
+${generateModuleInterfaces(analysis)}
+
+## Configuration
+
+### Environment Variables
+${generateEnvVars(analysis)}
+
+### Build Configuration
+${generateBuildConfig(analysis)}
+`;
+}
+
+export async function generateTasksDocument(projectPath: string, featureName: string): Promise<string> {
+  const analysis = await analyzeProject(projectPath);
+  const tasks = generateImplementationTasks(analysis);
+
+  const section = (title: string, list: Array<{ title: string; subtasks: string[]; requirements: string }>) =>
+    list.map((task, idx) => `- [ ] ${idx + 1}. ${task.title}
+  ${task.subtasks.map(s => `  - ${s}`).join('\n')}
+  - _Requirements: ${task.requirements}_`).join('\n\n');
+
+  return `# Implementation Plan
+
+## Project: ${featureName}
+
+**Project Name:** ${analysis.name}
+**Detected Stack:** ${[analysis.language, analysis.framework || '', analysis.buildTool || ''].filter(Boolean).join(' / ')}
+
+Generated on: ${new Date().toISOString()}
+
+## Development Phase Tasks
+
+${section('Development', tasks.development)}
+
+## Integration Phase Tasks
+
+${section('Integration', tasks.integration)}
+
+## Quality & Testing Tasks
+
+${section('Quality', tasks.quality)}
+`;
+}
+
+// Helpers derived from TemplateService, reduced and dependency-free
+function generateCoreObjective(analysis: any): string {
+  if (analysis.dependencies?.includes('@modelcontextprotocol/sdk')) return 'Provide MCP tools for spec-driven development workflows';
+  if (analysis.framework === 'Express.js') return 'Expose REST endpoints and middleware for business logic';
+  if (analysis.framework === 'React') return 'Render interactive UI components with state management';
+  return 'Deliver feature-aligned functionality integrated with existing architecture';
+}
+
+function generateAcceptanceCriteria(analysis: any): string[] {
+  const criteria = [
+    'WHEN invoked THEN it SHALL execute without runtime errors',
+    'IF input is invalid THEN it SHALL return meaningful errors',
+    'WHILE under typical load IT SHALL meet performance targets'
+  ];
+  if (analysis.testFramework) criteria.push('WHERE tests exist THEY SHALL pass with adequate coverage');
+  if (analysis.language === 'typescript') criteria.push('WHEN type-checking THEN no TypeScript errors SHALL occur');
+  return criteria;
+}
+
+function generateTechRequirements(analysis: any): string[] {
+  const out = ['Integrate with existing build and run scripts'];
+  if (analysis.dependencies?.includes('@modelcontextprotocol/sdk')) out.push('Expose MCP-compliant tools over stdio');
+  if (analysis.buildTool) out.push(`Provide build artifacts using ${analysis.buildTool}`);
+  return out;
+}
+
+function generateQualityRequirements(analysis: any): string[] {
+  const out = ['Follow project coding conventions', 'Apply error handling and logging'];
+  if (analysis.testFramework) out.push(`Include ${analysis.testFramework} tests for new code`);
+  return out;
+}
+
+function describeArchitecture(analysis: any): string {
+  if (analysis.architecture === 'Domain-Driven Design (DDD)') return 'Layered DDD: Domain, Application, Infrastructure, Presentation';
+  if (analysis.architecture.includes('API')) return 'REST API with routing, middleware, services, and data access layers';
+  if (analysis.framework === 'MCP SDK') return 'MCP server exposing development tools via stdio protocol';
+  return analysis.architecture || 'Modular architecture with clear separation of concerns';
+}
+
+function generateComponentList(analysis: any): Array<{ name: string; description: string }> {
+  const comps = [] as Array<{ name: string; description: string }>;
+  if (analysis.framework === 'MCP SDK') {
+    comps.push({ name: 'MCPServer', description: 'Handles stdio transport and tool registry' });
+    comps.push({ name: 'ToolHandlers', description: 'Implement SDD tools (init, requirements, design, tasks, etc.)' });
+  }
+  if (analysis.architecture.includes('API')) {
+    comps.push({ name: 'Controllers', description: 'HTTP route handlers' });
+    comps.push({ name: 'Services', description: 'Business logic orchestration' });
+  }
+  if (comps.length === 0) comps.push({ name: 'CoreModule', description: 'Primary feature implementation module' });
+  return comps;
+}
+
+function generateDataModels(analysis: any): string[] {
+  if (analysis.framework === 'MCP SDK') return ['Tool', 'Request', 'Response'];
+  if (analysis.architecture.includes('API')) return ['RequestDTO', 'ResponseDTO'];
+  return ['Entity', 'ValueObject'];
+}
+
+function generateDetailedTechStack(analysis: any): string {
+  const parts = [] as string[];
+  parts.push(`- Runtime: ${analysis.language === 'typescript' ? 'Node.js (TypeScript)' : 'Node.js (JavaScript)'}`);
+  if (analysis.framework) parts.push(`- Framework: ${analysis.framework}`);
+  if (analysis.buildTool) parts.push(`- Build: ${analysis.buildTool}`);
+  if (analysis.testFramework) parts.push(`- Testing: ${analysis.testFramework}`);
+  return parts.join('\n');
+}
+
+function generateDependencySummary(analysis: any): string {
+  const deps = (analysis.dependencies || []).slice(0, 10).map((d: string) => `- ${d}`).join('\n');
+  const dev = (analysis.devDependencies || []).slice(0, 10).map((d: string) => `- ${d}`).join('\n');
+  return `#### Production\n${deps || '- (none)'}\n\n#### Development\n${dev || '- (none)'}`;
+}
+
+function generateModuleInterfaces(analysis: any): string {
+  if (analysis.framework === 'MCP SDK') {
+    return `- registerTool(name: string, handler: (args) => Promise<unknown>)\n- connect(transport): Promise<void>`;
+  }
+  if (analysis.architecture.includes('API')) {
+    return `- handle(request): Response\n- service.process(input): Result`;
+  }
+  return `- execute(input): Output`;
+}
+
+function generateEnvVars(analysis: any): string {
+  const envs = ['NODE_ENV', 'LOG_LEVEL'];
+  if (analysis.framework === 'MCP SDK') envs.push('MCP_MODE');
+  return envs.map(e => `- ${e}`).join('\n');
+}
+
+function generateBuildConfig(analysis: any): string {
+  if (analysis.buildTool) return `Use ${analysis.buildTool} to emit production artifacts`;
+  return 'Use npm scripts (build/test/lint) defined in package.json';
+}
+
+function generateImplementationTasks(analysis: any) {
+  const dev = [
+    { title: 'Set up project scaffolding', subtasks: ['Initialize directories', 'Configure scripts'], requirements: 'FR-1' },
+    { title: 'Implement core feature logic', subtasks: ['Add modules', 'Wire integrations'], requirements: 'FR-1' }
+  ];
+  const integ = [
+    { title: 'Integrate with stack', subtasks: ['Validate build', 'Run dev server'], requirements: 'FR-2' }
+  ];
+  const quality = [
+    { title: 'Add tests and quality checks', subtasks: ['Unit tests', 'Lint/typecheck', 'Quality review'], requirements: 'FR-3' }
+  ];
+
+  // Tailor tasks if MCP or API
+  if (analysis.framework === 'MCP SDK') {
+    dev.unshift({ title: 'Expose MCP tools', subtasks: ['Register tools', 'Handle stdio transport'], requirements: 'FR-2' });
+  }
+  if (analysis.architecture.includes('API')) {
+    dev.unshift({ title: 'Add HTTP endpoints', subtasks: ['Define routes', 'Implement handlers'], requirements: 'FR-1' });
+  }
+
+  if (analysis.testFramework) {
+    quality[0].subtasks.unshift(`Set up ${analysis.testFramework}`);
+  }
+  if (analysis.language === 'typescript') {
+    quality[0].subtasks.push('Ensure type safety (tsc)');
+  }
+
+  return { development: dev, integration: integ, quality };
+}
+


### PR DESCRIPTION
This PR makes sdd-requirements, sdd-design, and sdd-tasks generate analysis-based documents on first run in MCP mode.\n\n- Adds specGenerator (TS + JS runtime)\n- Wires MCP simplified handlers and mcp-server.js to analysis-first with clear fallbacks\n- Adds smoke scripts (startup and tools/list)\n- Bumps version to 1.4.0 and updates CHANGELOG\n\nValidated in isolated /tmp project and via local build.\n\nCloses: # (optional)