### PR TITLE
release: publish v3.4.0 context handoffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,16 @@ build/
 # AI tool configs
 .serena/
 
+# Generated SDD agent installs
+# Created by: npx sdd-mcp-server@latest install --all
+.claude/agents/
+.claude/contexts/
+.claude/hooks/
+.claude/rules/
+.claude/skills/
+.agents/
+.codex/
+
 # OS files
 .DS_Store
 Thumbs.db

--- a/.spec/steering/product.md
+++ b/.spec/steering/product.md
@@ -1,50 +1,43 @@
 # Product Overview
 
-## Product Description
-MCP server for spec-driven development workflows across AI-agent CLIs and IDEs
+## Description
+SDD MCP Server is a Model Context Protocol server and companion CLI for running spec-driven development workflows across AI-agent CLIs and IDEs such as Claude Code and Cursor.
 
-**Project**: sdd-mcp-server
-**Version**: 1.4.4
-**Type**: Domain-Driven Design (DDD)
+The project packages workflow tools, agent skills, steering documents, rules, contexts, agents, and hooks so teams can move from project intent to requirements, design, tasks, implementation, review, and commit guidance with consistent governance.
 
-## Core Features
-- Automated testing framework
-- Build system for production deployment
-- Development server with hot reload
-- Code quality enforcement with linting
-- Type safety validation
-- MCP SDK framework integration
-- Docker containerization support
-- Jest testing suite
-- TypeScript type safety
-- Model Context Protocol (MCP) server capabilities
-- AI tool integration support
-- Spec-driven development workflow
-- Comprehensive multi-language codebase analysis (TypeScript, Java, Python, Go, Ruby, PHP, Rust, C#, Scala)
-- Framework detection (Spring Boot, Django, FastAPI, Rails, Laravel, Express, React, Vue, Angular, Next.js, 20+ frameworks)
-- Test-Driven Development (TDD) task generation with RED-GREEN-REFACTOR workflow
-- SOLID, DRY, KISS, YAGNI coding principles enforcement
-- OWASP Top 10 security checklist integration
-- 8 comprehensive steering documents for AI agent guidance
-
-## Target Use Case
-This product enables AI-powered development teams to follow structured, spec-driven development workflows with comprehensive phase management, quality gates, and AI tool integration.
-
-## Key Value Proposition
-- **Type Safety**: Compile-time type checking reduces runtime errors
-- **AI Integration**: Seamless integration with AI development tools
-- **Deployment Flexibility**: Container-based deployment for any environment
+## Vision
+Make disciplined spec-driven development practical inside AI-assisted engineering tools while keeping context usage controlled. The workflow should preserve human approval checkpoints and TDD discipline without forcing every interaction to load all guidance documents.
 
 ## Target Users
-- AI developers using Claude, Cursor, or similar tools
-- Development teams implementing spec-driven workflows
+- **Primary:** Engineers using AI coding agents who want a repeatable requirements -> design -> tasks -> implementation workflow.
+- **Secondary:** Team leads and maintainers standardizing AI-assisted development conventions across repositories.
+- **Tertiary:** MCP client and plugin authors who need a reference implementation for workflow tools, resources, prompts, and installable agent components.
+
+## Core Features
+1. MCP workflow tools - Initialize specs, inspect status, approve phases, validate design/gaps, run quality checks, and execute spec implementation.
+2. Agent skills - On-demand guidance for requirements, design, tasks, implementation, steering, simple tasks, review, security checks, tests, and commits.
+3. Component installer - Installs skills, steering, rules, contexts, agents, and hooks into consuming projects with lean and full profiles.
+4. Approval workflow - Enforces requirements, design, and tasks approval before implementation, with an optional TDD test-case review checkpoint.
+5. Context management - Generates compact handoff summaries after phase approvals and supports compact, standard, and full context loading modes.
+6. Quality and security guidance - Includes Linus-style review, OWASP-oriented checks, TDD guidance, and project-specific steering.
+7. Migration utilities - Supports migration from legacy `.kiro` and static steering layouts into the current `.spec` and component architecture.
+
+## Key Value Propositions
+- Reduces repeated prompt/context loading by moving template-heavy guidance into on-demand skills and compact handoffs.
+- Gives AI agents a deterministic workflow contract instead of ad hoc planning and implementation.
+- Keeps humans in control of phase approvals while still automating status, validation, and context restoration.
+- Works through MCP stdio and direct CLI usage, so the same workflow can serve multiple AI clients.
+- Ships reusable components that projects can install locally without copying source repo internals.
 
 ## Success Metrics
-- Zero linting errors in production code
-- Zero TypeScript compilation errors
+- Users can complete SDD phases with fewer full-context reloads and fewer repeated steering reads.
+- Default install profile keeps always-on guidance small while preserving full install options for teams that need them.
+- New workflow tools and skills are covered by focused unit tests and type checks.
+- README, package version examples, and install behavior stay aligned for published releases.
+- Context handoff summaries produce meaningful reductions compared with loading all source spec documents.
 
-## Technical Advantages
-- Strong typing prevents common JavaScript errors
-- Optimized builds with TypeScript Compiler
-- Domain-Driven Design ensures business alignment
-- Dependency injection for loose coupling and testability
+## Product Principles
+- Prefer explicit workflow state over implicit agent memory.
+- Keep generated project artifacts readable and editable by humans.
+- Use compact context by default and provide full context only when the task needs it.
+- Preserve backward compatibility for existing `.spec`, `.kiro`, and installed component users where practical.

--- a/.spec/steering/structure.md
+++ b/.spec/steering/structure.md
@@ -1,63 +1,113 @@
 # Project Structure
 
-## Directory Organization
+## Directory Layout
+
+```text
+sdd-mcp/
+├── src/
+│   ├── index.ts                  # Main MCP entry point and simplified stdio mode
+│   ├── adapters/cli/             # Tool adapter surface for CLI/MCP calls
+│   ├── application/services/     # Use cases and workflow orchestration
+│   ├── domain/                   # Types, ports, workflow state, quality/plugin contracts
+│   ├── infrastructure/           # MCP server, DI, adapters, schemas, templates, plugins
+│   ├── cli/                      # Install and migration CLIs
+│   ├── agents/                   # Source managers for installable agents
+│   ├── contexts/                 # Source managers for installable contexts
+│   ├── hooks/                    # Source managers for installable hooks
+│   ├── rules/                    # Source managers for installable rules
+│   ├── skills/                   # Source managers for installable skills
+│   ├── shared/                   # Shared helpers
+│   ├── utils/                    # Utility modules and generators
+│   └── __tests__/unit/           # Jest unit tests grouped by domain area
+├── skills/                       # Packaged Agent Skill source assets
+├── steering/                     # Packaged steering templates
+├── rules/                        # Packaged rule components
+├── contexts/                     # Packaged context components
+├── agents/                       # Packaged agent components
+├── hooks/                        # Packaged hook components
+├── .spec/steering/               # Project-specific steering documents
+├── .spec/specs/                  # SDD feature specs for this repository
+├── .claude-plugin/               # Claude plugin manifest
+├── dist/                         # TypeScript build output
+├── package.json                  # Package metadata, scripts, dependencies, binaries
+├── tsconfig.json                 # TypeScript compiler settings
+├── jest.config.js                # Jest ESM TypeScript test config
+├── Dockerfile                    # Multi-stage distroless production image
+└── README.md                     # User-facing usage and release documentation
 ```
-├── .spec/                    # SDD workflow files
-│   ├── steering/            # Project steering documents
-│   └── specs/              # Feature specifications
-├── data/                   # Project directory
-├── dist/                   # Build output
-├── locales/                   # Project directory
-├── plugins/                   # Project directory
-├── src/                   # Source code
-├── Dockerfile              # Container configuration
-├── package.json            # Project configuration
-├── tsconfig.json           # TypeScript configuration
-└── README.md               # Project documentation
+
+## Source Organization
+
+### Domain Layer
+- Keep domain types, ports, workflow state machines, quality contracts, and plugin contracts under `src/domain/`.
+- Domain code should not import infrastructure implementations.
+- Add new persistence, filesystem, validation, logging, template, or task-tracking boundaries as ports before wiring concrete adapters.
+
+### Application Layer
+- Put orchestration and use cases under `src/application/services/`.
+- Services should coordinate domain objects and ports, not own transport-specific MCP formatting.
+- Favor focused services such as `WorkflowEngineService`, `ProjectService`, `TemplateService`, and `ContextCompactionService` over expanding entrypoint logic.
+
+### Infrastructure Layer
+- Put MCP runtime code under `src/infrastructure/mcp/`.
+- Put concrete adapters under `src/infrastructure/adapters/`, repositories under `src/infrastructure/repositories/`, schemas under `src/infrastructure/schemas/`, and DI bindings under `src/infrastructure/di/`.
+- Register new services and adapters in `src/infrastructure/di/types.ts` and `src/infrastructure/di/container.ts`.
+
+### CLI and Entry Points
+- Use `src/index.ts` for MCP server startup and simplified mode compatibility.
+- Use `src/cli/` for install and migration commands.
+- Keep tool schemas and tool response behavior aligned between full adapter paths and simplified MCP paths when both are supported.
+
+### Packaged Components
+- Root `skills/`, `steering/`, `rules/`, `contexts/`, `agents/`, and `hooks/` are package source assets.
+- Generated local installs under `.claude/`, `.agents/`, and `.codex/` are project-local outputs and should not be treated as source assets.
+- When adding or renaming a component, update package files, installer tests, README tables, and any Codex/Claude conversion outputs as needed.
+
+## Naming Conventions
+
+### Files
+| Type | Convention | Example |
+|------|------------|---------|
+| Services | PascalCase with `Service` suffix | `WorkflowEngineService.ts` |
+| Adapters | PascalCase with `Adapter` suffix | `NodeFileSystemAdapter.ts` |
+| Managers | PascalCase with `Manager` suffix | `TemplateManager.ts` |
+| State machines | PascalCase descriptive name | `WorkflowStateMachine.ts` |
+| Schemas | Lowercase domain name with `.schema.ts` | `project.schema.ts` |
+| Tests | Match subject plus `.test.ts` | `ContextCompactionService.test.ts` |
+| CLI modules | Kebab-case for command files where established | `install-skills.ts` |
+| Skill docs | `SKILL.md` inside skill directory | `skills/sdd-design/SKILL.md` |
+
+### Code
+| Element | Convention | Example |
+|---------|------------|---------|
+| Classes and types | PascalCase | `ProjectService`, `WorkflowOptions` |
+| Interfaces and ports | PascalCase, usually no `I` prefix | `ProjectRepository`, `LoggerPort` |
+| Functions and methods | camelCase | `generatePhaseHandoff` |
+| Constants | UPPER_SNAKE_CASE or PascalCase object exports depending on local pattern | `TYPES`, `DEFAULT_LOCALE` |
+| Variables | camelCase | `featureName`, `specPath` |
+
+## Module Conventions
+- Use ESM imports and include `.js` extensions for local runtime imports in TypeScript source where the existing code does.
+- Prefer named exports for services, types, and utilities.
+- Keep type-only imports as `import type` when importing only TypeScript types.
+- Preserve dependency direction: presentation/adapters -> application -> domain, with infrastructure implementing domain ports.
+- Avoid adding new global state in entrypoints; prefer DI-managed services or small local helpers for compatibility paths.
+
+## Testing Conventions
+- Unit tests live under `src/__tests__/unit/` and are grouped by area, such as `cli`, `context`, `workflow`, `skills`, `rules`, `hooks`, and `utils`.
+- Add focused tests near the behavior changed; broaden coverage when touching shared workflow contracts or installer behavior.
+- Use the shell-safe unit command in zsh when needed:
+
+```bash
+npx jest '--testPathPattern=__tests__.*\.test\.ts$' '--testPathIgnorePattern=integration|e2e'
 ```
 
-## Key Directories
-- **src/**: Main source code directory containing application logic
-- **dist/build/**: Compiled output for production deployment
-
-## Code Organization Patterns
-- **Domain-Driven Design**: Business logic isolated in domain layer
-- **Dependency Injection**: IoC container for managing dependencies
-
-## File Naming Conventions
-- TypeScript files: `.ts` extension
-- Type definition files: `.d.ts` extension
-- Test files: `.test.ts` or `.spec.ts` suffix
-- Configuration files: `.json` or `.config.js` format
-- Directories: lowercase with hyphens (e.g., `user-service`)
-- Constants: UPPER_SNAKE_CASE
-- Functions/Variables: camelCase
-- Classes/Types: PascalCase
-
-## Module Organization
-### Domain-Driven Modules
-- Each domain has its own module with models, services, and repositories
-- Clear boundaries between different domains
-- Dependency flow from infrastructure → application → domain
-
-## Architectural Principles
-- **Separation of Concerns**: Each module handles a specific responsibility
-- **Type Safety**: Leverage TypeScript for compile-time type checking
-- **Dependency Inversion**: Depend on abstractions, not concrete implementations
-
-## Development Patterns
-- Hot module replacement for rapid development
-- Automated code quality checks on commit
-- Strict TypeScript configuration for maximum safety
-
-## Testing Structure
-Testing structure to be implemented
+## Generated Files and Git Hygiene
+- Do not commit `dist/`, coverage output, or local installed agent artifacts.
+- `.claude/`, `.agents/`, and `.codex/` generated install outputs are ignored except for files already tracked historically.
+- Do not revert unrelated changes in `.spec/`, generated local agent directories, or user-modified docs while implementing a focused change.
 
 ## Build Output
-### Build Process
-- Command: `npm run build`
-- Output directory: `dist/`
-- Build tool: TypeScript Compiler
-- TypeScript compilation to JavaScript
-- Source maps for debugging
-
+- `npm run build` emits compiled JavaScript, declarations, and source maps to `dist/`.
+- Package publication includes compiled runtime files and root component asset directories listed in `package.json`.
+- Runtime MCP usage should work through `npx -y sdd-mcp-server@latest`, global install, or the local `mcp-server.js` development entry.

--- a/.spec/steering/tech.md
+++ b/.spec/steering/tech.md
@@ -1,96 +1,103 @@
-# Technology Stack
+# Technology Overview
+
+## Stack
+
+### Language and Runtime
+- **Primary language:** TypeScript 5.x
+- **Runtime:** Node.js >= 18
+- **Module system:** ESM (`"type": "module"`)
+- **Build target:** ES2022
+- **Package manager:** npm with `package-lock.json`
+
+### Core Frameworks and Protocols
+- **Model Context Protocol SDK:** MCP server primitives, tools, resources, prompts, and stdio transport.
+- **Inversify:** Dependency injection container for clean architecture wiring.
+- **Handlebars:** Template rendering for generated documents and project artifacts.
+- **AJV and Zod:** Runtime validation for schemas and structured input.
+- **i18next:** Localization infrastructure.
+- **Jest and ts-jest:** Unit testing for TypeScript ESM modules.
+
+### Key Dependencies
+| Package | Purpose |
+|---------|---------|
+| `@modelcontextprotocol/sdk` | MCP server integration and protocol types |
+| `inversify` + `reflect-metadata` | Dependency injection for application and infrastructure services |
+| `handlebars` | Template rendering and document generation |
+| `ajv` + `ajv-formats` | JSON schema validation |
+| `zod` | Structured schema definitions and validation |
+| `@babel/parser`, `acorn`, `esprima`, `typescript-estree` | Source parsing and quality/codebase analysis |
+| `i18next` packages | Localization services |
+| `uuid` | Stable IDs for projects and workflow objects |
 
 ## Architecture
-**Type**: Domain-Driven Design (DDD)  
-**Language**: TypeScript  
-**Module System**: ES Module  
-**Framework**: MCP SDK  
-**Build Tool**: TypeScript Compiler
 
+### Pattern
+The codebase follows a clean architecture / hexagonal style:
 
-### Domain-Driven Design Architecture
-The project follows DDD principles with clear separation between:
-- **Domain Layer**: Business logic and domain models
-- **Application Layer**: Use cases and application services  
-- **Infrastructure Layer**: External dependencies and integrations
-- **Presentation Layer**: API endpoints or UI components
+```text
+src/index.ts, src/cli, src/adapters
+  -> presentation and command/tool adapters
 
+src/application/services
+  -> workflow orchestration and use cases
 
-## Technology Stack
-- **Node.js**: JavaScript runtime for server-side execution
-- **TypeScript**: Typed superset of JavaScript for enhanced developer experience
-- **MCP SDK**: Model Context Protocol SDK for AI agent integration
-- **Jest**: Testing framework for unit and integration tests
-- **TypeScript Compiler**: Build and bundling tool for production optimization
-- **@babel/parser**: Project dependency
-- **@babel/types**: Project dependency
-- **@modelcontextprotocol/sdk**: MCP SDK for AI tool integration
-- **@typescript-eslint/typescript-estree**: Project dependency
-- **acorn**: Project dependency
+src/domain
+  -> ports, types, workflow state, quality contracts, plugin contracts
 
-## Development Environment
-- **Node Version**: >=18.0.0
-- **Package Manager/Build**: npm
-- **Language**: TypeScript with type safety
-- **Testing**: Jest
-
-## Dependencies Analysis
-### Production Dependencies (16)
-- `@babel/parser`: Project dependency
-- `@babel/types`: Project dependency
-- `@modelcontextprotocol/sdk`: MCP SDK for AI tool integration
-- `@typescript-eslint/typescript-estree`: Project dependency
-- `acorn`: Project dependency
-- `ajv`: JSON schema validator
-- `ajv-formats`: Project dependency
-- `esprima`: Project dependency
-- `handlebars`: Template engine
-- `i18next`: Internationalization framework
-- `i18next-fs-backend`: Project dependency
-- `i18next-http-middleware`: Project dependency
-- `inversify`: Dependency injection container
-- `os-locale`: Project dependency
-- `reflect-metadata`: Project dependency
-
-... and 1 more
-
-### Development Dependencies (16)
-- `@types/esprima`: Project dependency
-- `@types/handlebars`: Project dependency
-- `@types/jest`: Project dependency
-- `@types/node`: Project dependency
-- `@types/sinon`: Project dependency
-- `@types/supertest`: Project dependency
-- `@types/uuid`: Project dependency
-- `@typescript-eslint/eslint-plugin`: Project dependency
-- `@typescript-eslint/parser`: Project dependency
-- `eslint`: JavaScript linter
-
-... and 6 more
-
-## Development Commands
-```bash
-npm run dev  # Start development server with hot reload
-npm run start  # Start production server
-npm run build  # Build project for production
-npm run test  # Run test suite
-npm run lint  # Check code quality with linter
-npm run typecheck  # Validate TypeScript types
-npm run test:unit  # jest --testPathPattern=__tests__.*\.test\.ts$ --te...
-npm run test:integration  # jest --testPathPattern=integration.*\.test\.ts$
-npm run test:e2e  # jest --testPathPattern=e2e.*\.test\.ts$
-npm run test:watch  # jest --watch
-npm run test:coverage  # jest --coverage
-npm run test:ci  # jest --coverage --ci --watchAll=false --passWithNo...
-npm run lint:fix  # eslint src --ext .ts --fix
-npm run validate  # npm run typecheck && npm run lint && npm run test:...
+src/infrastructure
+  -> MCP server, filesystem/config adapters, DI, schemas, templates, plugins
 ```
 
-## Quality Assurance
-- **Linting**: Automated code quality checks
-- **Type Checking**: TypeScript compilation validation
+Domain ports live in `src/domain/ports.ts` and are implemented in infrastructure adapters. Application services depend on ports and domain types; `src/infrastructure/di/container.ts` binds concrete implementations with Inversify.
 
-## Deployment Configuration
-- **Containerization**: Docker support for consistent deployments
-- **Build Process**: `npm run build` for production artifacts
-- **Module System**: ES modules for modern JavaScript
+### Main Runtime Paths
+- `src/index.ts` starts the MCP server and includes the simplified MCP mode used by `npx`/stdio clients.
+- `src/infrastructure/mcp/` implements MCP server concerns: tool registry, prompts, resources, sessions, capability negotiation, and errors.
+- `src/adapters/cli/SDDToolAdapter.ts` maps tool calls into application services.
+- `src/cli/` contains install and migration commands.
+- `src/application/services/ContextCompactionService.ts` handles compact handoff generation and context loading.
+
+## Development Environment
+
+### Setup
+```bash
+npm install
+npm run build
+npm start
+```
+
+### Common Commands
+| Command | Purpose |
+|---------|---------|
+| `npm run dev` | Run `src/index.ts` with `tsx watch` |
+| `npm run build` | Compile TypeScript into `dist/` |
+| `npm run start` | Run the compiled server |
+| `npm run typecheck` | Run `tsc --noEmit` |
+| `npm run lint` | Run ESLint over `src/**/*.ts` |
+| `npm run test` | Run Jest |
+| `npm run test:unit` | Run unit tests only; quote the ignore pattern in zsh if invoking manually |
+| `npm run test:coverage` | Generate coverage reports |
+| `npm run validate` | Typecheck, lint, and coverage CI test |
+
+### Packaging
+- Published package name: `sdd-mcp-server`
+- Current version: `3.4.0`
+- Binaries:
+  - `sdd-mcp-server` -> `sdd-entry.js`
+  - `sdd-install-skills` -> `dist/cli/install-skills.js`
+- Published component directories include `skills`, `steering`, `rules`, `contexts`, `agents`, and `hooks`.
+
+### Docker
+The Docker build is multi-stage:
+- `node:18-alpine` builder
+- production dependencies stage
+- `gcr.io/distroless/nodejs18-debian11` runtime
+
+The production image is intended to run with a minimal attack surface and no shell.
+
+## Quality Standards
+- Keep `npm run typecheck` passing before delivery.
+- Use focused Jest unit tests for workflow, installer, context, validation, and service behavior.
+- Maintain the configured global coverage threshold of 80% for branches, functions, lines, and statements in coverage runs.
+- Use existing port/service abstractions before adding new infrastructure dependencies.
+- Keep generated or installed local agent components out of source control unless they are source assets under root `skills/`, `rules/`, `contexts/`, `agents/`, `hooks/`, or `steering/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,222 +1,79 @@
-# AI Agent Spec-Driven Development
+# CLAUDE.md - Spec-Driven Development (SDD)
 
-Hybrid MCP + Agent Skills implementation for spec-driven development.
+This project uses the SDD workflow powered by `sdd-mcp-server`.
 
 ## Two Development Paths
 
-Choose the appropriate path based on task complexity:
-
 ### Path A: Simple Task (`/simple-task`)
-For small features, bug fixes, quick enhancements.
-
-```
-User: "Add a logout button"
-→ /simple-task
-→ References: tdd-guideline.md, principles.md, linus-review.md, owasp-top10-check.md
-→ Implements with best practices
-```
+For small features, bug fixes, and quick enhancements.
 
 ### Path B: Full SDD Workflow
 For complex features requiring formal specification.
 
-```
-User: "Build user authentication system"
-→ sdd-init → /sdd-requirements → /sdd-design → /sdd-tasks → /sdd-implement
-→ Full approval workflow at each phase
+```text
+sdd-init -> /sdd-requirements -> /sdd-design -> /sdd-tasks -> /sdd-implement
 ```
 
----
+Each phase requires human approval before proceeding.
 
-## Reference Documents (Steering)
+## Installed Components
 
-These documents provide guidance and can be referenced by skills:
+### Skills (`.claude/skills/`)
+On-demand guidance invoked via slash commands:
 
-| Document | Purpose |
-|----------|---------|
-| `tdd-guideline.md` | TDD Red-Green-Refactor methodology |
-| `principles.md` | SOLID, DRY, KISS, YAGNI, Separation of Concerns |
-| `linus-review.md` | Code quality and "good taste" criteria |
-| `owasp-top10-check.md` | OWASP Top 10 security checklist |
+| Skill | Purpose |
+|-------|---------|
+| `/simple-task` | Quick implementation with best practices |
+| `/sdd-requirements` | EARS-formatted requirements generation |
+| `/sdd-design` | Architecture design with quality principles |
+| `/sdd-tasks` | TDD task breakdown with test pyramid |
+| `/sdd-implement` | Implementation guidelines (SOLID, security, TDD) |
+| `/sdd-steering` | Create/update project steering documents |
+| `/sdd-steering-custom` | Custom steering for specialized contexts |
+| `/sdd-commit` | Commit message and PR guidelines |
+| `/sdd-review` | Code review skill |
+| `/sdd-security-check` | Security audit skill |
+| `/sdd-test-gen` | Test generation skill |
 
-Located in `.spec/steering/` (or `.kiro/steering/` for legacy projects).
+### Rules (`.claude/rules/`)
+Always-active coding standards: coding style, error handling, git workflow, SDD workflow, security, testing.
 
----
+### Contexts (`.claude/contexts/`)
+Switchable modes: dev, planning, research, review, security audit.
 
-## Architecture (v3.0)
+### Agents (`.claude/agents/`)
+Specialized roles: architect, implementer, planner, reviewer, security auditor, TDD guide.
 
-This project uses a **comprehensive plugin architecture** with 6 component types:
+### Hooks (`.claude/hooks/`)
+Lifecycle events: session start/end, pre/post tool use.
 
-- **MCP Tools**: Action-oriented operations (init, status, approve, quality-check, validate, spec-impl)
-- **Skills**: Workflow guidance (requirements, design, tasks, steering, implement, commit)
-- **Steering**: Project-wide conventions (TDD, principles, security, code review)
-- **Rules**: Always-active guidelines (coding-style, testing, security, git-workflow)
-- **Contexts**: Mode-specific prompts (dev, review, planning, security-audit, research)
-- **Agents**: Specialized AI personas (planner, architect, reviewer, implementer)
-- **Hooks**: Event-driven automation (pre-tool-use, post-tool-use, session events)
+### Steering (`.spec/steering/`)
+Project-specific context documents. Edit these to describe your project:
 
-### Install All Components
-
-```bash
-# Recommended: Install everything
-npx sdd-mcp-server install --all
-
-# Or install specific components
-npx sdd-mcp-server install --skills --steering
-npx sdd-mcp-server install --rules --agents
-```
-
-## Project Context
-
-### Paths
-- Steering: `.spec/steering/`
-- Specs: `.spec/specs/`
-- Skills: `.claude/skills/`
-
-### Steering Documents
-
-**Reference Documents** (guidance for skills):
-- `tdd-guideline.md`: TDD methodology and test pyramid
-- `principles.md`: SOLID, DRY, KISS, YAGNI, Modularity
-- `linus-review.md`: Code quality and "good taste" criteria
-- `owasp-top10-check.md`: OWASP Top 10 security checklist
-
-**Project-Specific** (describe YOUR project):
-- `product.md`: Product context and business objectives
-- `tech.md`: Technology stack and decisions
-- `structure.md`: File organization and patterns
-
-## Workflow
-
-### Phase 0: Setup (One-time)
-```bash
-# Install all SDD components to your project
-npx sdd-mcp-server install --all
-```
-
-### Phase 1: Steering (Optional)
-`/sdd-steering` (Skill) - Create/update project-specific steering documents
-`/sdd-steering-custom` (Skill) - Create custom steering for specialized contexts
-
-### Phase 2: Specification Creation
-1. `sdd-init` (MCP Tool) - Initialize spec with project description
-2. `/sdd-requirements <feature>` (Skill) - Generate EARS-formatted requirements
-3. `sdd-approve --phase requirements` (MCP Tool) - Approve requirements
-4. `/sdd-design <feature>` (Skill) - Create architecture design
-5. `sdd-validate-design` (MCP Tool) - GO/NO-GO design review
-6. `sdd-approve --phase design` (MCP Tool) - Approve design
-7. `/sdd-tasks <feature>` (Skill) - Generate TDD task breakdown
-8. `sdd-approve --phase tasks` (MCP Tool) - Approve tasks
-
-### Phase 3: Implementation
-- `/sdd-implement <feature>` (Skill) - Implementation guidelines with SOLID, security, TDD
-- `sdd-spec-impl` (MCP Tool) - Execute tasks with TDD methodology
-- `sdd-quality-check` (MCP Tool) - Linus-style code review
-
-### Phase 4: Commit
-- `/sdd-commit` (Skill) - Commit message and PR guidelines
-
-### Progress Tracking
-- `sdd-status` (MCP Tool) - Check current progress and phases
-- `sdd-context-load` (MCP Tool) - Restore project context
+- `product.md` - Product context and business objectives
+- `tech.md` - Technology stack and decisions
+- `structure.md` - File organization and patterns
 
 ## MCP Tools
 
 | Tool | Description |
 |------|-------------|
-| `sdd-init` | Initialize new SDD project |
+| `sdd-init` | Initialize new SDD spec |
 | `sdd-status` | Check workflow progress |
 | `sdd-approve` | Approve workflow phases |
+| `sdd-review-test-cases` | Mark optional TDD test-case review complete |
 | `sdd-quality-check` | Code quality analysis |
-| `sdd-context-load` | Load project context |
+| `sdd-context-load` | Load compact, standard, or full project context |
 | `sdd-validate-design` | Design quality validation |
 | `sdd-validate-gap` | Implementation gap analysis |
 | `sdd-spec-impl` | Execute tasks with TDD |
-| `sdd-list-skills` | List available Agent Skills |
 
-## Agent Skills
+## Workflow
 
-| Skill | Description |
-|-------|-------------|
-| `/simple-task` | Quick implementation with best practices (references steering docs) |
-| `/sdd-requirements` | EARS-formatted requirements with quality checklist |
-| `/sdd-design` | Architecture design with Linus principles |
-| `/sdd-tasks` | TDD task breakdown with test pyramid guidance |
-| `/sdd-implement` | Implementation guidelines (SOLID, security, TDD) |
-| `/sdd-steering` | Project-specific steering documents |
-| `/sdd-steering-custom` | Custom steering with inclusion modes |
-| `/sdd-commit` | Commit/PR guidelines with conventional commits |
-| `/sdd-review` | **NEW** Linus-style direct code review with severity levels |
-| `/sdd-security-check` | **NEW** OWASP Top 10 security audit checklist |
-| `/sdd-test-gen` | **NEW** TDD test generation with Red-Green-Refactor workflow |
-
-## Token Efficiency
-
-Skills are loaded **on-demand** instead of always-on steering:
-
-- Old: ~3,800 tokens loaded for every operation
-- New: ~1,700 tokens loaded only when skill invoked
-- **Savings**: ~55% fewer tokens!
-
-## Development Rules
-
-1. **Install components first**: Run `npx sdd-mcp-server install --all`
-2. **Use skills for guidance**: `/sdd-requirements`, `/sdd-design`, `/sdd-tasks`, `/sdd-implement`
-3. **Use MCP tools for actions**: `sdd-init`, `sdd-approve`, `sdd-status`, `sdd-spec-impl`
-4. **Follow 3-phase approval workflow**: Requirements → Design → Tasks → Implementation
-5. **Approval required**: Each phase requires human review
-6. **No skipping phases**: Design requires approved requirements; Tasks require approved design
-
-## Component Locations
-
-### Steering Documents (`.spec/steering/`)
-- `tdd-guideline.md`: TDD Red-Green-Refactor methodology
-- `principles.md`: SOLID, DRY, KISS, YAGNI, Separation of Concerns
-- `linus-review.md`: Code quality "good taste" criteria
-- `owasp-top10-check.md`: OWASP Top 10 security checklist
-- `product.md`: Product context and business objectives (project-specific)
-- `tech.md`: Technology stack and decisions (project-specific)
-- `structure.md`: File organization and patterns (project-specific)
-
-### Skills (`.claude/skills/`)
-- `/simple-task`: Quick implementation with steering doc references
-- `/sdd-requirements`: EARS format templates
-- `/sdd-design`: Architecture pattern templates
-- `/sdd-tasks`: Task breakdown templates
-- `/sdd-implement`: Extended implementation checklists
-- `/sdd-commit`: Commit/PR templates
-- `/sdd-review`: Linus-style code review
-- `/sdd-security-check`: OWASP Top 10 audit
-- `/sdd-test-gen`: TDD test generation
-
-### Rules (`.claude/rules/`)
-Always-active guidelines loaded at session start:
-- `coding-style.md`: TypeScript/JS conventions
-- `testing.md`: TDD requirements
-- `security.md`: OWASP guidelines
-- `git-workflow.md`: Commit conventions
-- `error-handling.md`: Error patterns
-- `sdd-workflow.md`: Phase order enforcement
-
-### Contexts (`.claude/contexts/`)
-Mode-specific prompts activated by task type:
-- `dev.md`: Implementation focus
-- `review.md`: Quality focus
-- `planning.md`: Architecture focus
-- `security-audit.md`: Threat focus
-- `research.md`: Exploration focus
-
-### Agents (`.claude/agents/`)
-Specialized AI personas invoked for specific tasks:
-- `planner.md`: Roadmap & planning
-- `architect.md`: System design
-- `reviewer.md`: Code review (Linus-style)
-- `implementer.md`: TDD implementation
-- `security-auditor.md`: Vulnerability assessment
-- `tdd-guide.md`: Test-driven coaching
-
-### Hooks (`.claude/hooks/`)
-Event-driven automation:
-- `pre-tool-use/`: Validation before tool execution
-- `post-tool-use/`: Logging and status updates
-- `session-start/`: Context loading
-- `session-end/`: Cleanup and reminders
+1. **Setup**: `npx sdd-mcp-server install` for lean install, or `npx sdd-mcp-server install --profile full` for all components.
+2. **Steering**: `/sdd-steering` to update project-specific docs when needed.
+3. **Specify**: `sdd-init` -> `/sdd-requirements` -> `/sdd-design` -> `/sdd-tasks`, approving each phase.
+4. **Context**: use `sdd-context-load` compact mode for routine continuation; use `mode: "full"` only when needed.
+5. **Implement**: `/sdd-implement` or `sdd-spec-impl`.
+6. **Review**: `sdd-quality-check`.
+7. **Commit**: `/sdd-commit`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,845 +1,643 @@
 # MCP SDD Server Architecture
 
-**Version**: 3.0.3
-**Last Updated**: 2026-01-24
+**Version**: 3.4.0  
+**Last Updated**: 2026-06-22  
 **Status**: Production
-
----
-
-## Table of Contents
-
-1. [Overview](#overview)
-2. [System Architecture](#system-architecture)
-3. [Layered Architecture](#layered-architecture)
-4. [Module Loading System](#module-loading-system)
-5. [MCP Protocol Integration](#mcp-protocol-integration)
-6. [Workflow Engine](#workflow-engine)
-7. [Requirements Clarification System](#requirements-clarification-system)
-8. [Plugin System](#plugin-system)
-9. [Data Flow](#data-flow)
-10. [Security Architecture](#security-architecture)
-11. [Deployment Models](#deployment-models)
 
 ---
 
 ## Overview
 
-The MCP SDD Server is a **Model Context Protocol (MCP)** server that implements **Spec-Driven Development (SDD)** workflows for AI-agent CLIs and IDEs. It provides a structured approach to software development through:
+SDD MCP Server is a Model Context Protocol server and companion CLI for spec-driven development workflows. It gives AI-agent clients a structured path from project intent to requirements, design, TDD tasks, implementation, review, and commit guidance.
 
-- **Automated Requirements Clarification**: Analyzes project descriptions and interactively gathers missing information
-- **Steering Document Generation**: Creates context-rich documentation from codebase analysis
-- **Workflow State Management**: Guides teams through Requirements → Design → Tasks → Implementation phases
-- **Cross-Context Compatibility**: Unified module loading supporting npx, npm, node, and Docker execution
+The current architecture is hybrid:
 
-### Key Design Principles
+- **MCP tools** execute stateful actions: initialize specs, approve phases, inspect status, load context, validate, and run quality checks.
+- **Agent skills** carry template-heavy guidance: requirements, design, tasks, implementation, steering, review, security, tests, and commits.
+- **Installable components** package optional rules, contexts, agents, hooks, skills, and steering templates for consuming projects.
+- **Compact handoffs** preserve workflow continuity without repeatedly loading full phase documents.
 
-- **Domain-Driven Design (DDD)**: Clear separation between domain logic, application services, and infrastructure
-- **SOLID Principles**: Single Responsibility, Open/Closed, Liskov Substitution, Interface Segregation, Dependency Inversion
-- **Dependency Injection**: Inversify container for loose coupling and testability
-- **Test-Driven Development (TDD)**: 100% test coverage for critical paths
-- **Security by Design**: OWASP Top 10 aligned, input sanitization, least privilege
+This split exists to keep workflow behavior deterministic while reducing always-on context usage.
 
 ---
 
-## System Architecture
+## System Context
 
 ```mermaid
 graph TB
     subgraph "AI Clients"
-        A1[Claude Code]
-        A2[Cursor IDE]
-        A3[Other MCP Clients]
+        Claude["Claude Code"]
+        Cursor["Cursor"]
+        Other["Other MCP Clients"]
     end
 
-    subgraph "MCP Server - Entry Points"
-        B1[mcp-server.js<br/>Legacy Entry]
-        B2[dist/index.js<br/>TypeScript Entry]
+    subgraph "Runtime Entrypoints"
+        NPX["npx sdd-mcp-server"]
+        Global["sdd-mcp-server"]
+        Local["mcp-server.js / dist/index.js"]
+        Docker["Docker image"]
     end
 
-    subgraph "Module Loader v1.6.2"
-        ML[moduleLoader.ts<br/>Unified Loader]
-        ML1[Path 1: ./utils/*.js<br/>npm start, node dist/]
-        ML2[Path 2: ../utils/*.js<br/>npm run dev]
-        ML3[Path 3: ./*.js<br/>npx context]
-        ML4[Path 4: ../*.js<br/>Alternative npx]
+    subgraph "SDD MCP Server"
+        MCP["MCP Server"]
+        Tools["MCP Tools"]
+        Adapter["SDDToolAdapter"]
+        Services["Application Services"]
+        Domain["Domain Model and Ports"]
+        Infra["Infrastructure Adapters"]
     end
 
-    subgraph "Core Modules"
-        C1[documentGenerator<br/>Codebase Analysis]
-        C2[specGenerator<br/>Spec Documents]
+    subgraph "Project Artifacts"
+        Specs[".spec/specs/{feature}"]
+        Steering[".spec/steering"]
+        Handoffs["context/handoff.md"]
+        Components[".claude / .agents / .codex installs"]
     end
 
-    subgraph "MCP Infrastructure"
-        D1[MCPServer<br/>Protocol Handler]
-        D2[ToolRegistry<br/>Tool Management]
-        D3[SessionManager<br/>State Management]
-    end
-
-    subgraph "Application Layer"
-        E1[WorkflowEngine<br/>Phase Management]
-        E2[RequirementsClarification<br/>Interactive Q&A]
-        E3[SteeringDocuments<br/>Context Generation]
-    end
-
-    subgraph "Domain Layer"
-        F1[ProjectContext<br/>Business Logic]
-        F2[WorkflowStateMachine<br/>FSM]
-        F3[QualityGate<br/>Validation]
-    end
-
-    subgraph "Infrastructure"
-        G1[FileSystemPort<br/>I/O Abstraction]
-        G2[LoggerPort<br/>Logging]
-        G3[PluginManager<br/>Extensibility]
-    end
-
-    A1 & A2 & A3 --> B1 & B2
-    B2 --> ML
-    ML --> ML1 & ML2 & ML3 & ML4
-    ML1 & ML2 & ML3 & ML4 --> C1 & C2
-    B1 & B2 --> D1
-    D1 --> D2 & D3
-    D2 --> E1 & E2 & E3
-    E1 & E2 & E3 --> F1 & F2 & F3
-    F1 & F2 & F3 --> G1 & G2 & G3
+    Claude --> NPX
+    Cursor --> NPX
+    Other --> Global
+    NPX --> MCP
+    Global --> MCP
+    Local --> MCP
+    Docker --> MCP
+    MCP --> Tools
+    Tools --> Adapter
+    Adapter --> Services
+    Services --> Domain
+    Services --> Infra
+    Infra --> Specs
+    Infra --> Steering
+    Services --> Handoffs
+    NPX --> Components
 ```
 
 ---
 
 ## Layered Architecture
 
-The system follows a **4-layer hexagonal architecture** pattern:
+The codebase follows a clean architecture / hexagonal style.
 
 ```mermaid
 graph LR
-    subgraph "Presentation Layer"
-        P1[MCP Tools API]
-        P2[CLI Interface]
-    end
+    Presentation["Presentation<br/>src/index.ts<br/>src/cli<br/>src/adapters"]
+    Application["Application<br/>src/application/services"]
+    Domain["Domain<br/>src/domain"]
+    Infrastructure["Infrastructure<br/>src/infrastructure"]
+    Assets["Packaged Components<br/>skills, steering, rules,<br/>contexts, agents, hooks"]
 
-    subgraph "Application Layer"
-        A1[Services]
-        A2[Use Cases]
-        A3[DTOs]
-    end
-
-    subgraph "Domain Layer"
-        D1[Entities]
-        D2[Value Objects]
-        D3[Domain Services]
-        D4[Business Rules]
-    end
-
-    subgraph "Infrastructure Layer"
-        I1[File System]
-        I2[Database]
-        I3[External APIs]
-        I4[Logging]
-    end
-
-    P1 & P2 --> A1 & A2
-    A1 & A2 --> D1 & D2 & D3 & D4
-    A1 & A2 --> I1 & I2 & I3 & I4
-    D3 --> I1
-
-    style D1 fill:#e1f5fe
-    style D2 fill:#e1f5fe
-    style D3 fill:#e1f5fe
-    style D4 fill:#e1f5fe
+    Presentation --> Application
+    Application --> Domain
+    Application --> Infrastructure
+    Infrastructure --> Domain
+    Presentation --> Assets
 ```
 
-### Layer Responsibilities
+### Presentation
 
-#### 1. Presentation Layer (`/src/infrastructure/mcp`, `/src/adapters`)
-- **MCP Protocol Handling**: Translates MCP requests to application commands
-- **Tool Registration**: Exposes SDD tools (sdd-init, sdd-steering, etc.)
-- **Session Management**: Maintains client connection state
-- **Error Formatting**: Converts internal errors to MCP error responses
+Primary locations:
 
-#### 2. Application Layer (`/src/application/services`)
-- **Orchestration**: Coordinates domain services and infrastructure
-- **Use Case Implementation**: Implements business workflows
-- **Data Transformation**: Converts between DTOs and domain objects
-- **Transaction Management**: Ensures consistency across operations
+- `src/index.ts`
+- `src/cli/`
+- `src/adapters/cli/SDDToolAdapter.ts`
+- `src/infrastructure/mcp/`
 
-Key Services:
-- `RequirementsClarificationService`: Orchestrates the 5 specialized services
-- `WorkflowEngineService`: Manages SDD phase transitions
-- `SteeringDocumentService`: Generates steering documents
-- `ProjectInitializationService`: Initializes new SDD projects
+Responsibilities:
 
-#### 3. Domain Layer (`/src/domain`)
-- **Business Logic**: Core business rules and validation
-- **Domain Models**: Entities, value objects, aggregates
-- **Domain Services**: Business operations that don't belong to entities
-- **Workflow State Machine**: Finite state machine for SDD phases
+- Start the MCP server and simplified stdio mode.
+- Register and execute MCP tools.
+- Expose CLI commands such as `install`, `install-skills`, `migrate-kiro`, and `migrate-steering`.
+- Convert tool arguments and service results into MCP-compatible responses.
 
-Domain Components:
-- `ProjectContext`: Root aggregate for project state
-- `WorkflowStateMachine`: FSM (requirements → design → tasks → implementation)
-- `QualityGate`: Validation rules for phase transitions
+### Application
 
-#### 4. Infrastructure Layer (`/src/infrastructure`)
-- **Ports & Adapters**: Implements domain interfaces
-- **External Services**: File I/O, logging, databases
-- **Framework Integration**: MCP SDK, Inversify DI container
-- **Plugin System**: Dynamic tool and steering document loading
+Primary location: `src/application/services/`
+
+Responsibilities:
+
+- Orchestrate SDD use cases.
+- Coordinate domain state, filesystem writes, templates, validation, and quality checks.
+- Generate compact context handoffs after approvals.
+- Manage project initialization, workflow progression, status, and checkpoints.
+
+Important services:
+
+- `ProjectService`
+- `WorkflowService`
+- `WorkflowEngineService`
+- `TemplateService`
+- `ContextCompactionService`
+- `ProjectInitializationService`
+- `RequirementsClarificationService`
+- `SteeringDocumentService`
+- `QualityService`
+
+### Domain
+
+Primary location: `src/domain/`
+
+Responsibilities:
+
+- Define workflow types, project metadata, approvals, checkpoints, tasks, quality reports, and ports.
+- Enforce workflow transition rules through `WorkflowStateMachine`.
+- Keep business contracts independent from MCP, filesystem, and package runtime details.
+
+Key files:
+
+- `src/domain/types.ts`
+- `src/domain/ports.ts`
+- `src/domain/workflow/WorkflowStateMachine.ts`
+- `src/domain/quality/`
+- `src/domain/plugins/`
+- `src/domain/templates/`
+
+### Infrastructure
+
+Primary location: `src/infrastructure/`
+
+Responsibilities:
+
+- Implement domain ports for filesystem, logging, validation, templates, repositories, quality analysis, and configuration.
+- Own the Inversify container and runtime bindings.
+- Implement MCP server components such as tool registry, prompt manager, resource manager, sessions, and capability negotiation.
+- Provide plugin and hook infrastructure.
+
+Key files:
+
+- `src/infrastructure/di/container.ts`
+- `src/infrastructure/di/types.ts`
+- `src/infrastructure/mcp/ToolRegistry.ts`
+- `src/infrastructure/mcp/MCPServer.ts`
+- `src/infrastructure/adapters/NodeFileSystemAdapter.ts`
+- `src/infrastructure/schemas/project.schema.ts`
 
 ---
 
-## Module Loading System
+## Hybrid Tool and Skill Model
 
-**Introduced in v1.6.2** to fix cross-context module loading issues.
-
-### Problem Statement
-
-Prior to v1.6.2, hardcoded import paths in `src/index.ts` failed when run via npx:
-
-```typescript
-// ❌ OLD: Breaks in npx context
-const { analyzeProject } = await import("./utils/documentGenerator.js");
-```
-
-**Root Cause**: Different execution contexts have different working directories:
-- `npm start`: CWD = `/dist/`
-- `npm run dev`: CWD = `/dist/tools/`
-- `node dist/index.js`: CWD = `/dist/`
-- `npx sdd-mcp-server`: CWD = `/node_modules/.bin/`
-
-### Solution Architecture
+The project intentionally separates action execution from guidance loading.
 
 ```mermaid
-graph TD
-    A[Handler Function Needs Module] --> B[loadDocumentGenerator OR loadSpecGenerator]
-    
-    B --> C{Try Path 1<br/>./utils/*.js}
-    C -->|Success| Z[Return Module]
-    C -->|Fail| D{Try Path 2<br/>../utils/*.js}
-    
-    D -->|Success| Z
-    D -->|Fail| E{Try Path 3<br/>./*.js}
-    
-    E -->|Success| Z
-    E -->|Fail| F{Try Path 4<br/>../*.js}
-    
-    F -->|Success| Z
-    F -->|Fail| G[Throw Error<br/>with all attempted paths]
-    
-    Z --> H[Log Success Path<br/>console.error SDD-DEBUG]
-    
-    style Z fill:#c8e6c9
-    style G fill:#ffcdd2
-    style H fill:#fff9c4
+graph TB
+    Request["User request"]
+    Skill["Agent Skill<br/>template and process guidance"]
+    Tool["MCP Tool<br/>stateful action"]
+    Spec[".spec/specs/{feature}"]
+    Handoff["Compact handoff"]
+
+    Request --> Skill
+    Request --> Tool
+    Skill --> Tool
+    Tool --> Spec
+    Tool --> Handoff
 ```
 
-### Implementation Details
+### MCP Tools
 
-**File**: `src/utils/moduleLoader.ts`
+MCP tools are for operations that mutate state, inspect state, validate, or load context.
 
-```typescript
-export async function loadDocumentGenerator(): Promise<DocumentGeneratorModule> {
-  const paths = [
-    './utils/documentGenerator.js',    // Priority 1: npm start, node dist/index.js
-    '../utils/documentGenerator.js',   // Priority 2: npm run dev (CWD=dist/tools/)
-    './documentGenerator.js',          // Priority 3: npx (CWD=node_modules/.bin/)
-    '../documentGenerator.js'          // Priority 4: Alternative npx context
-  ];
+| Tool | Role |
+|------|------|
+| `sdd-init` | Create a feature spec and metadata |
+| `sdd-status` | Report workflow progress |
+| `sdd-approve` | Approve requirements, design, or tasks |
+| `sdd-review-test-cases` | Mark optional TDD test-case review as complete |
+| `sdd-quality-check` | Run code quality analysis |
+| `sdd-context-load` | Load compact, standard, or full project context |
+| `sdd-validate-design` | Validate design quality |
+| `sdd-validate-gap` | Compare requirements/design against implementation |
+| `sdd-spec-impl` | Execute implementation tasks with TDD methodology |
+| `sdd-list-skills` | List installable skills |
 
-  const errors: string[] = [];
+Compatibility handlers may still exist for template-oriented operations in adapter code, but the user-facing architecture treats guidance-heavy workflows as skills.
 
-  for (const path of paths) {
-    try {
-      const module = await import(path);
-      console.error(`[SDD-DEBUG] ✅ Loaded documentGenerator from: ${path}`);
-      return module as DocumentGeneratorModule;
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      errors.push(`${path}: ${errorMessage}`);
-    }
-  }
+### Agent Skills
 
-  throw new Error(
-    `Failed to load documentGenerator. Attempted paths:\n${errors.map(e => `  - ${e}`).join('\n')}`
-  );
-}
-```
+Skills are loaded only when invoked by the user or agent client.
 
-**Key Features**:
-- ✅ **Sequential Fallback**: Tries 4 paths in priority order
-- ✅ **Comprehensive Error Messages**: Lists all attempted paths on failure
-- ✅ **Debug Logging**: Logs successful path with `console.error` for troubleshooting
-- ✅ **Type Safety**: Strong TypeScript interfaces for loaded modules
-- ✅ **Zero Dependencies**: Pure ES module imports, no external libraries
-
-### Integration Points
-
-Updated 4 handler functions in `src/index.ts`:
-
-1. **handleSteeringSimplified** (line ~436): Uses `loadDocumentGenerator()`
-2. **handleRequirementsSimplified** (line ~1189): Uses `loadSpecGenerator()`
-3. **handleDesignSimplified** (line ~1350): Uses `loadSpecGenerator()`
-4. **handleTasksSimplified** (line ~1476): Uses `loadSpecGenerator()`
+| Skill | Role |
+|-------|------|
+| `/simple-task` | Small changes with best-practice guidance |
+| `/sdd-requirements` | EARS requirements generation |
+| `/sdd-design` | Architecture design guidance |
+| `/sdd-tasks` | TDD task breakdown |
+| `/sdd-implement` | Implementation guidance |
+| `/sdd-steering` | Project-specific steering updates |
+| `/sdd-steering-custom` | Specialized steering |
+| `/sdd-review` | Linus-style review |
+| `/sdd-security-check` | OWASP-oriented review |
+| `/sdd-test-gen` | TDD test generation |
+| `/sdd-commit` | Commit and PR guidance |
 
 ---
 
-## MCP Protocol Integration
+## Component Installation Architecture
 
-```mermaid
-sequenceDiagram
-    participant AI as AI Client<br/>(Claude Code)
-    participant MCP as MCPServer
-    participant TR as ToolRegistry
-    participant AS as Application Service
-    participant DL as Domain Layer
-    participant FS as FileSystem Port
+The package ships source assets for installable agent components:
 
-    AI->>MCP: MCP Request<br/>tool: sdd-init
-    MCP->>TR: lookupTool("sdd-init")
-    TR->>MCP: ToolDefinition
-    MCP->>AS: ProjectInitializationService.init()
-    
-    AS->>DL: Validate project description
-    DL->>AS: QualityScore: 45%
-    
-    alt Score < 70%
-        AS->>AI: Interactive Clarification Questions
-        AI->>AS: User Answers
-        AS->>DL: Enrich Description with 5W1H
-    end
-    
-    AS->>FS: Create .spec/specs/{feature}/
-    AS->>FS: Write spec.json
-    FS->>AS: Success
-    
-    AS->>MCP: ToolResult (success)
-    MCP->>AI: MCP Response<br/>with spec details
+```text
+skills/      -> .claude/skills/ or .agents/skills/
+steering/    -> .spec/steering/
+rules/       -> .claude/rules/
+contexts/    -> .claude/contexts/
+agents/      -> .claude/agents/
+hooks/       -> .claude/hooks/
 ```
 
-### MCP Server Components
+The installer is implemented in `src/cli/install-skills.ts`.
 
-#### MCPServer (`/src/infrastructure/mcp/MCPServer.ts`)
-- **Responsibilities**: Protocol translation, error handling, capability negotiation
-- **Dependencies**: ToolRegistry, SessionManager, LoggerPort
-- **Lifecycle**: Singleton, initialized via DI container
+### Install Profiles
 
-#### ToolRegistry (`/src/infrastructure/mcp/ToolRegistry.ts`)
-- **Responsibilities**: Tool registration, lookup, parameter validation
-- **Tool Definition**: JSON Schema validation for tool parameters
-- **Extensibility**: Supports plugin-provided tools
+| Profile | Components | Purpose |
+|---------|------------|---------|
+| `lean` | skills, steering, hooks | Default lower-context setup |
+| `full` | skills, steering, rules, contexts, agents, hooks | Complete component installation |
 
-#### SessionManager (`/src/infrastructure/mcp/SessionManager.ts`)
-- **Responsibilities**: Client session tracking, state persistence
-- **State Storage**: In-memory with optional Redis backend
-- **Session Lifecycle**: Create → Active → Closed
+Examples:
+
+```bash
+npx sdd-mcp-server install
+npx sdd-mcp-server install --profile full
+npx sdd-mcp-server install --skills --rules --agents
+npx sdd-mcp-server install --list
+```
+
+Generated local installs under `.claude/`, `.agents/`, and `.codex/` are project outputs. Source assets live in the root component directories and are included in the npm package.
 
 ---
 
 ## Workflow Engine
 
-The SDD workflow follows a finite state machine with 5 phases:
+The core workflow is requirements -> design -> tasks -> implementation.
 
 ```mermaid
 stateDiagram-v2
     [*] --> Init: sdd-init
-    
-    Init --> Requirements: Auto-generate requirements.md
-    Requirements --> RequirementsApproval: User reviews
-    
-    RequirementsApproval --> Design: sdd-design<br/>(if approved)
-    RequirementsApproval --> Requirements: Reject (revise)
-    
-    Design --> DesignApproval: User reviews
-    DesignApproval --> Tasks: sdd-tasks<br/>(if approved)
-    DesignApproval --> Design: Reject (revise)
-    
-    Tasks --> TasksApproval: User reviews
-    TasksApproval --> Implementation: sdd-implement<br/>(if approved)
-    TasksApproval --> Tasks: Reject (revise)
-    
-    Implementation --> Testing: Run tests
-    Testing --> Done: All tests pass
-    Testing --> Implementation: Failures (fix)
-    
-    Done --> [*]
-    
-    note right of Requirements
-        requirements.md
-        - User stories
-        - Acceptance criteria
-        - Non-functional requirements
-    end note
-    
-    note right of Design
-        design.md
-        - Architecture
-        - Component design
-        - Data models
-    end note
-    
-    note right of Tasks
-        tasks.md
-        - Task breakdown
-        - Dependencies
-        - Estimates
-    end note
+    Init --> Requirements: requirements generated
+    Requirements --> RequirementsApproved: sdd-approve requirements
+    RequirementsApproved --> Design: design generated
+    Design --> DesignApproved: sdd-approve design
+    DesignApproved --> Tasks: tasks generated
+    Tasks --> TestCaseReview: reviewTestCases required
+    TestCaseReview --> TasksApproved: sdd-review-test-cases + sdd-approve tasks
+    Tasks --> TasksApproved: no checkpoint
+    TasksApproved --> Implementation: implementation ready
+    Implementation --> [*]
 ```
 
-### Workflow State Persistence
+### Project Metadata
 
-**File**: `.spec/specs/{feature-name}/spec.json`
+Workflow state is stored in `.spec/specs/{feature}/spec.json`.
+
+Important fields:
 
 ```json
 {
-  "feature_name": "user-authentication",
-  "phase": "design-approved",
   "approvals": {
-    "requirements": {
-      "generated": true,
-      "approved": true,
-      "approved_at": "2025-11-05T10:30:00Z"
-    },
-    "design": {
-      "generated": true,
-      "approved": true,
-      "approved_at": "2025-11-05T14:20:00Z"
-    },
-    "tasks": {
-      "generated": false,
-      "approved": false
+    "requirements": { "generated": true, "approved": true },
+    "design": { "generated": true, "approved": true },
+    "tasks": { "generated": true, "approved": false }
+  },
+  "workflow_options": {
+    "review_test_cases": true
+  },
+  "checkpoints": {
+    "test_cases": {
+      "required": true,
+      "reviewed": false
     }
   },
-  "metadata": {
-    "created_at": "2025-11-05T09:00:00Z",
-    "updated_at": "2025-11-05T14:20:00Z",
-    "project_path": "/path/to/project"
-  }
+  "ready_for_implementation": false
 }
 ```
 
+### TDD Test-Case Review Checkpoint
+
+The optional checkpoint can be enabled at initialization or task generation time. When enabled:
+
+- Tasks can be generated normally.
+- `sdd-approve tasks` is blocked until test cases are reviewed.
+- `sdd-review-test-cases` marks the checkpoint as reviewed.
+- Implementation readiness requires approved requirements, approved design, approved tasks, and a reviewed checkpoint.
+
+This keeps the default workflow lightweight while allowing teams to require human review before implementation begins.
+
 ---
 
-## Requirements Clarification System
+## Context Management
 
-**Introduced in v1.5.0, refactored in v1.6.0** following Single Responsibility Principle.
+Long SDD workflows can become context intensive if every phase reloads all steering and spec documents. The current architecture reduces this with automatic handoffs.
 
-### Architecture (v1.6.0+)
+### Automatic Handoff Generation
 
-```mermaid
-graph TD
-    A[User provides project description] --> B[SteeringContextLoader]
-    B --> C[Load existing steering docs]
-    C --> D[DescriptionAnalyzer]
-    
-    D --> E[Semantic Analysis:<br/>WHY WHO WHAT SUCCESS]
-    E --> F{Quality Score<br/>>= 70%?}
-    
-    F -->|Yes| G[Generate requirements.md]
-    F -->|No| H[QuestionGenerator]
-    
-    H --> I[Generate targeted questions]
-    I --> J[Present questions to user]
-    J --> K[User provides answers]
-    K --> L[AnswerValidator]
-    
-    L --> M{Valid<br/>answers?}
-    M -->|No| N[Request clarification]
-    N --> K
-    M -->|Yes| O[DescriptionEnricher]
-    
-    O --> P[Synthesize 5W1H enriched description]
-    P --> G
-    
-    style F fill:#fff9c4
-    style M fill:#fff9c4
-    style G fill:#c8e6c9
+When a phase is approved, `WorkflowEngineService` calls `ContextCompactionService.generatePhaseHandoff`.
+
+```text
+sdd-approve requirements -> .spec/specs/{feature}/context/requirements-handoff.md
+sdd-approve design       -> .spec/specs/{feature}/context/design-handoff.md
+sdd-approve tasks        -> .spec/specs/{feature}/context/tasks-handoff.md
+latest handoff           -> .spec/specs/{feature}/context/handoff.md
 ```
 
-### 5 Specialized Services
+The handoff contains:
 
-#### 1. SteeringContextLoader
-- **Purpose**: Load existing steering documents (product.md, tech.md)
-- **Input**: Project path
-- **Output**: SteeringContext (flags for existing docs)
-- **Location**: `src/application/services/SteeringContextLoader.ts`
+- Current workflow state.
+- Approval status.
+- TDD test-case checkpoint status.
+- Compact summaries of available phase documents.
+- Next actions.
+- Source references.
+- Estimated context reduction.
 
-#### 2. DescriptionAnalyzer
-- **Purpose**: Analyze project description quality (0-100 score)
-- **Scoring Factors**:
-  - WHY present (+30 points): Business justification
-  - WHO present (+20 points): Target users
-  - WHAT present (+20 points): Core features
-  - SUCCESS present (+15 points): Metrics
-  - Ambiguity penalty (-5 per term, max -15)
-  - Length bonus (+5 per threshold: 100, 300, 500 chars)
-- **Location**: `src/application/services/DescriptionAnalyzer.ts`
+### Context Load Modes
 
-#### 3. QuestionGenerator
-- **Purpose**: Generate targeted clarification questions
-- **Question Selection**: Based on analysis gaps and steering context
-- **Configuration**: Externalized to `clarification-questions.ts`
-- **Location**: `src/application/services/QuestionGenerator.ts`
+`sdd-context-load` supports three modes:
 
-#### 4. AnswerValidator
-- **Purpose**: Validate and sanitize user answers
-- **Validations**:
-  - Required fields present
-  - Minimum length (10 chars)
-  - XSS/injection detection
-  - Path traversal prevention
-- **Location**: `src/application/services/AnswerValidator.ts`
+| Mode | Contents | Use case |
+|------|----------|----------|
+| `compact` | `context/handoff.md` | Routine continuation |
+| `standard` | handoff plus `spec.json` | Status-sensitive continuation |
+| `full` | requirements, design, tasks, and spec metadata | Audits or ambiguous decisions |
 
-#### 5. DescriptionEnricher
-- **Purpose**: Synthesize enriched description with 5W1H structure
-- **Output Format**:
-  ```
-  WHY: {business justification}
-  WHO: {target users}
-  WHAT: {core features}
-  HOW: {technical approach}
-  SUCCESS: {metrics and KPIs}
-  ```
-- **Location**: `src/application/services/DescriptionEnricher.ts`
+Compact mode is the default. Full mode is explicit so agents do not accidentally reload every phase document for routine work.
+
+### Quantitative Target
+
+Token estimates use a deterministic `characters / 4` approximation. Typical compact handoffs target a 60-85% reduction compared with loading `requirements.md`, `design.md`, `tasks.md`, and `spec.json` in full. Actual savings depend on spec length and document structure.
 
 ---
 
-## Plugin System
+## Requirements Clarification
+
+`RequirementsClarificationService` is composed from smaller services:
+
+```mermaid
+graph TB
+    Input["Project description"]
+    Steering["SteeringContextLoader"]
+    Analyze["DescriptionAnalyzer"]
+    Questions["QuestionGenerator"]
+    Validate["AnswerValidator"]
+    Enrich["DescriptionEnricher"]
+    Init["ProjectInitializationService"]
+
+    Input --> Steering
+    Steering --> Analyze
+    Analyze --> Questions
+    Questions --> Validate
+    Validate --> Enrich
+    Enrich --> Init
+```
+
+Responsibilities:
+
+- Load existing product and technical steering.
+- Score descriptions for why, who, what, and success criteria.
+- Ask targeted clarification questions when needed.
+- Validate answer quality and reject unsafe content.
+- Synthesize an enriched 5W1H description for downstream requirements generation.
+
+---
+
+## Module Loading
+
+The runtime includes a small compatibility loader in `src/utils/moduleLoader.ts` for document and spec generator modules. It exists because local development, compiled execution, and npx execution can resolve files from different package-relative paths.
+
+The loader:
+
+- Attempts known relative paths in order.
+- Logs the successful path to stderr for MCP-safe debugging.
+- Reports all attempted paths on failure.
+- Keeps the public handler code independent from one execution layout.
+
+This remains a compatibility layer, not the central architecture boundary.
+
+---
+
+## Dependency Injection
+
+Inversify wires application services to domain ports and infrastructure adapters.
+
+```mermaid
+graph TB
+    Container["createContainer()"]
+    Ports["Domain Ports"]
+    Adapters["Infrastructure Adapters"]
+    Services["Application Services"]
+    MCP["MCP Components"]
+
+    Container --> Ports
+    Container --> Adapters
+    Container --> Services
+    Container --> MCP
+    Services --> Ports
+    Adapters --> Ports
+    MCP --> Services
+```
+
+Typical bindings:
+
+- `ProjectRepository` -> `InMemoryProjectRepository`
+- `FileSystemPort` -> `NodeFileSystemAdapter`
+- `TemplateEngine` -> `HandlebarsTemplateEngine`
+- `ValidationPort` -> `AjvValidationAdapter`
+- `LoggerPort` -> `ConsoleLoggerAdapter`
+- `QualityAnalyzer` -> `LinusQualityAnalyzer`
+- `ContextCompactionService` -> application service binding
+
+When adding a new cross-cutting dependency, prefer adding a domain port and infrastructure adapter instead of importing concrete infrastructure directly into domain or application code.
+
+---
+
+## Plugin and Hook System
+
+The plugin architecture is split across:
+
+- `PluginManager`
+- `HookSystem`
+- `PluginToolRegistry`
+- `PluginSteeringRegistry`
 
 ```mermaid
 graph LR
-    subgraph "Core System"
-        A[PluginManager]
-        B[HookSystem]
-        C[PluginToolRegistry]
-        D[PluginSteeringRegistry]
-    end
+    Manager["PluginManager"]
+    Hooks["HookSystem"]
+    Tools["PluginToolRegistry"]
+    Steering["PluginSteeringRegistry"]
+    Runtime["MCP Runtime"]
 
-    subgraph "Plugin Types"
-        E[Tool Plugins]
-        F[Steering Plugins]
-        G[Hook Plugins]
-    end
-
-    subgraph "Hooks"
-        H[pre-init]
-        I[post-requirements]
-        J[pre-design]
-        K[post-tasks]
-    end
-
-    A --> E & F & G
-    B --> H & I & J & K
-    E --> C
-    F --> D
-    G --> B
+    Manager --> Hooks
+    Manager --> Tools
+    Manager --> Steering
+    Tools --> Runtime
+    Hooks --> Runtime
+    Steering --> Runtime
 ```
 
-### Plugin Development
-
-**Location**: `.spec/plugins/`
-
-**Example Tool Plugin**:
-```typescript
-// .spec/plugins/custom-validator/index.ts
-export default {
-  name: 'custom-validator',
-  type: 'tool',
-  version: '1.0.0',
-  
-  tool: {
-    name: 'validate-requirements',
-    description: 'Custom requirements validator',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        featureName: { type: 'string' }
-      },
-      required: ['featureName']
-    },
-    
-    async execute(args: any) {
-      // Custom validation logic
-      return { valid: true, issues: [] };
-    }
-  }
-};
-```
+Hooks can support event-driven behavior such as pre-tool validation, post-tool status updates, and session lifecycle reminders. Installable hook definitions are packaged under root `hooks/`.
 
 ---
 
 ## Data Flow
 
-### Document Generation Flow
+### Phase Approval and Handoff
 
 ```mermaid
 sequenceDiagram
-    participant U as User
-    participant AI as AI Agent
-    participant Tool as sdd-steering
-    participant ML as ModuleLoader
-    participant DG as DocumentGenerator
-    participant FS as FileSystem
-    participant CB as Codebase
+    participant Client as AI Client
+    participant MCP as MCP Server
+    participant Adapter as SDDToolAdapter
+    participant Workflow as WorkflowEngineService
+    participant Project as ProjectService
+    participant Context as ContextCompactionService
+    participant FS as FileSystemPort
 
-    U->>AI: "Generate steering docs"
-    AI->>Tool: tool: sdd-steering<br/>args: {projectPath}
-    Tool->>ML: loadDocumentGenerator()
-    
-    ML->>ML: Try ./utils/documentGenerator.js
-    alt Path 1 Success
-        ML->>Tool: Module loaded
-    else Path 1 Fail
-        ML->>ML: Try ../utils/documentGenerator.js
-        ML->>Tool: Module loaded (or try next path)
+    Client->>MCP: sdd-approve phase
+    MCP->>Adapter: execute tool
+    Adapter->>Workflow: update approval status
+    Workflow->>Project: load and update project
+    Project->>FS: write spec.json
+    Workflow->>Context: generatePhaseHandoff
+    Context->>FS: read phase documents
+    Context->>FS: write context/handoff.md
+    Context->>FS: write context/{phase}-handoff.md
+    Workflow-->>Adapter: approval result + estimate
+    Adapter-->>Client: approved + handoff path
+```
+
+### Context Restore
+
+```mermaid
+sequenceDiagram
+    participant Client as AI Client
+    participant Tool as sdd-context-load
+    participant Context as ContextCompactionService
+    participant FS as FileSystemPort
+
+    Client->>Tool: feature, mode
+    Tool->>Context: loadContext(project, mode)
+    alt compact
+        Context->>FS: read context/handoff.md
+    else standard
+        Context->>FS: read handoff.md and spec.json
+    else full
+        Context->>FS: read requirements/design/tasks/spec
     end
-    
-    Tool->>DG: analyzeProject(projectPath)
-    DG->>CB: Read package.json
-    DG->>CB: Detect languages
-    DG->>CB: Find frameworks
-    DG->>CB: Analyze structure
-    CB->>DG: Project metadata
-    
-    DG->>Tool: ProjectAnalysis
-    Tool->>DG: generateProductDocument(analysis)
-    Tool->>DG: generateTechDocument(analysis)
-    Tool->>DG: generateStructureDocument(analysis)
-    
-    Tool->>FS: Write .spec/steering/product.md
-    Tool->>FS: Write .spec/steering/tech.md
-    Tool->>FS: Write .spec/steering/structure.md
-    
-    FS->>Tool: Success
-    Tool->>AI: Documents generated
-    AI->>U: "Steering docs created successfully"
+    Context-->>Tool: context text
+    Tool-->>Client: context payload
 ```
 
 ---
 
 ## Security Architecture
 
-### Defense in Depth Layers
+Security is mostly local-tool hardening rather than network perimeter security.
 
-```mermaid
-graph TB
-    subgraph "Layer 1: Input Validation"
-        A1[JSON Schema Validation]
-        A2[Type Safety TypeScript]
-        A3[Parameter Sanitization]
-    end
+| Area | Approach |
+|------|----------|
+| Input validation | JSON schema and service-level validation |
+| Description answers | XSS, JavaScript URL, path traversal, and minimum-quality checks |
+| Filesystem writes | Scoped project artifact paths and explicit directory creation |
+| MCP output | Structured tool responses and error handling |
+| Dependencies | npm lockfile and audit-friendly package structure |
+| Container runtime | Multi-stage build with distroless Node.js runtime |
+| Secrets | No credential storage by design |
 
-    subgraph "Layer 2: Application Security"
-        B1[Path Traversal Prevention]
-        B2[XSS/Injection Detection]
-        B3[Rate Limiting]
-        B4[Input Length Limits]
-    end
-
-    subgraph "Layer 3: Runtime Security"
-        C1[Least Privilege Principle]
-        C2[File Permission Checks]
-        C3[Error Message Sanitization]
-        C4[Logging without Secrets]
-    end
-
-    subgraph "Layer 4: Container Security"
-        D1[Distroless Base Image]
-        D2[Non-root User UID 1001]
-        D3[Read-only Filesystem]
-        D4[Dropped Capabilities]
-    end
-
-    A1 & A2 & A3 --> B1 & B2 & B3 & B4
-    B1 & B2 & B3 & B4 --> C1 & C2 & C3 & C4
-    C1 & C2 & C3 & C4 --> D1 & D2 & D3 & D4
-```
-
-### OWASP Top 10 Alignment
-
-| OWASP Risk | Mitigation | Implementation |
-|------------|-----------|----------------|
-| A01: Broken Access Control | Path traversal prevention | `src/application/services/AnswerValidator.ts` |
-| A02: Cryptographic Failures | No sensitive data storage | Stateless design, no credentials |
-| A03: Injection | Input sanitization | Regex-based XSS/SQL detection |
-| A04: Insecure Design | Security by design | `.spec/steering/security-check.md` |
-| A05: Security Misconfiguration | Secure defaults | Docker distroless, non-root user |
-| A06: Vulnerable Components | Dependency scanning | `npm audit` in CI/CD |
-| A07: Authentication Failures | N/A | No authentication (local tool) |
-| A08: Software & Data Integrity | Immutable builds | Distroless read-only filesystem |
-| A09: Logging Failures | Structured logging | LoggerPort with correlation IDs |
-| A10: SSRF | No external requests | Offline-first design |
+The Dockerfile builds with Node 18 Alpine and runs the production artifact in `gcr.io/distroless/nodejs18-debian11`.
 
 ---
 
 ## Deployment Models
 
-### 1. NPX (Recommended)
+### NPX
 
 ```bash
 npx -y sdd-mcp-server@latest
 ```
 
-**Advantages**:
-- ✅ No installation required
-- ✅ Always uses latest version
-- ✅ No version conflicts
-- ✅ Secure: npm registry verification
+Recommended for most MCP client configuration because it avoids manual global installs.
 
-**Module Loading**: Path 3 (`./documentGenerator.js`) or Path 4 (`../documentGenerator.js`)
-
-### 2. Global Installation
+### Global Install
 
 ```bash
 npm install -g sdd-mcp-server@latest
 sdd-mcp-server
 ```
 
-**Advantages**:
-- ✅ Persistent installation
-- ✅ Faster startup (no download)
-- ✅ Offline usage after install
+Useful for persistent local environments.
 
-**Module Loading**: Path 1 (`./utils/documentGenerator.js`)
-
-### 3. Docker
+### Local Development
 
 ```bash
-docker run -p 3000:3000 ghcr.io/yi-john-huang/sdd-mcp:latest
+npm install
+npm run build
+npm start
 ```
 
-**Advantages**:
-- ✅ Isolated environment
-- ✅ Reproducible builds
-- ✅ Security hardened (distroless)
-
-**Module Loading**: Path 1 (`./utils/documentGenerator.js`)
-
-### 4. Local Development
+For Claude Code local development:
 
 ```bash
-git clone https://github.com/yi-john-huang/sdd-mcp.git
-npm run dev
+claude mcp add sdd "$(pwd)/mcp-server.js" -s local
 ```
 
-**Advantages**:
-- ✅ Fastest development cycle
-- ✅ Hot reload with tsx
-- ✅ Full debugging support
+### Docker
 
-**Module Loading**: Path 2 (`../utils/documentGenerator.js`)
-
----
-
-## Performance Characteristics
-
-### Module Loading Performance
-
-| Execution Context | First Import (ms) | Cached Import (ms) | Fallback Attempts |
-|------------------|-------------------|--------------------|--------------------|
-| npm start | 10-20 | <5 | 1 (Path 1) |
-| npm run dev | 15-25 | <5 | 2 (Path 2) |
-| node dist/index.js | 10-20 | <5 | 1 (Path 1) |
-| npx | 50-100* | <5 | 3-4 (Path 3-4) |
-
-*Includes npm package download on first run
-
-### Document Generation Performance
-
-| Operation | Time (ms) | Notes |
-|-----------|-----------|-------|
-| Analyze project | 200-500 | Depends on project size |
-| Generate product.md | 50-100 | Template rendering |
-| Generate tech.md | 100-200 | Framework detection |
-| Generate structure.md | 150-300 | Directory traversal |
-| **Total** | **500-1100** | ~1 second end-to-end |
-
-### Memory Usage
-
-| Component | Heap (MB) | Notes |
-|-----------|-----------|-------|
-| Base server | 20-30 | MCP SDK + Inversify |
-| Document generation | +10-20 | File I/O buffers |
-| Requirements clarification | +5-10 | Analysis state |
-| **Peak** | **40-60** | Typical usage |
+```bash
+docker build --target production -t sdd-mcp-server .
+docker run -p 3000:3000 sdd-mcp-server
+```
 
 ---
 
 ## Testing Strategy
 
-```mermaid
-graph TD
-    subgraph "Test Pyramid"
-        A[Unit Tests<br/>71 tests<br/>100% coverage]
-        B[Integration Tests<br/>Manual validation]
-        C[E2E Tests<br/>Cross-context validation]
-    end
+Test and validation commands:
 
-    subgraph "Test Frameworks"
-        D[Jest<br/>Unit + Integration]
-        E[TypeScript<br/>Type checking]
-        F[ESLint<br/>Code quality]
-    end
+| Command | Purpose |
+|---------|---------|
+| `npm run typecheck` | TypeScript compile validation |
+| `npm run lint` | ESLint over source |
+| `npm run test` | Jest test suite |
+| `npm run test:unit` | Unit tests |
+| `npm run test:coverage` | Coverage reports |
+| `npm run validate` | Typecheck, lint, and CI coverage run |
 
-    A --> D
-    B --> D
-    C --> D
-    D --> E --> F
+In zsh, quote the unit test patterns when invoking Jest directly:
+
+```bash
+npx jest '--testPathPattern=__tests__.*\.test\.ts$' '--testPathIgnorePattern=integration|e2e'
 ```
 
-### Test Coverage (v1.6.2)
-
-- **Unit Tests**: 71 tests passing
-  - moduleLoader: 6 tests (100% coverage)
-  - RequirementsClarification: 62 tests (95% coverage)
-  - Existing: 3 tests
-- **Integration Tests**: Manual cross-context validation
-  - npm start ✅
-  - npm run dev ✅
-  - node dist/index.js ✅
-  - npx ✅
-- **E2E Tests**: Production npx validation ✅
+Coverage thresholds are configured in `jest.config.js` at 80% for branches, functions, lines, and statements.
 
 ---
 
-## Future Architecture Considerations
+## Evolution Notes
 
-### Planned Improvements (v1.7.0+)
+Important architecture shifts:
 
-1. **Distributed Workflow State**
-   - Redis backend for SessionManager
-   - Multi-instance coordination
-   - Shared workflow state
-
-2. **Enhanced Plugin System**
-   - TypeScript plugin development
-   - Plugin dependency resolution
-   - Sandboxed plugin execution
-
-3. **GraphQL API**
-   - Alternative to MCP for web clients
-   - Real-time subscriptions
-   - Schema introspection
-
-4. **AI Model Integration**
-   - Local LLM support (Ollama, LM Studio)
-   - Semantic analysis improvements
-   - Automated code review
-
-5. **Telemetry & Observability**
-   - OpenTelemetry integration
-   - Distributed tracing
-   - Performance metrics
+- `.kiro` compatibility remains, but `.spec` is the current project artifact standard.
+- Static steering guidance was consolidated into installable skills, rules, agents, and hooks.
+- The default install profile is lean to reduce always-on context.
+- Phase approvals now write compact context handoffs automatically.
+- Optional TDD test-case review is represented as workflow metadata and enforced before tasks approval when enabled.
+- Generated local agent installs are ignored; root component directories are the package source assets.
 
 ---
 
 ## References
 
-- **MCP Specification**: https://modelcontextprotocol.io
-- **Source Code**: https://github.com/yi-john-huang/sdd-mcp
-- **npm Package**: https://www.npmjs.com/package/sdd-mcp-server
-- **Issue Tracker**: https://github.com/yi-john-huang/sdd-mcp/issues
+- [README.md](README.md)
+- [AGENTS.md](AGENTS.md)
+- [.spec/steering/product.md](.spec/steering/product.md)
+- [.spec/steering/tech.md](.spec/steering/tech.md)
+- [.spec/steering/structure.md](.spec/steering/structure.md)
+- [Model Context Protocol](https://modelcontextprotocol.io)
+- [npm package](https://www.npmjs.com/package/sdd-mcp-server)
+- [GitHub repository](https://github.com/yi-john-huang/sdd-mcp)
 
 ---
 
 **Maintained by**: SDD MCP Server Team  
 **License**: MIT  
-**Last Review**: 2026-01-12
+**Last Review**: 2026-06-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0] - 2026-06-22
+
+### Added
+- **Automatic context handoffs**: Phase approvals now generate compact handoff files under `.spec/specs/{feature}/context/`
+  - `sdd-context-load` defaults to compact context for routine workflow continuation
+  - Supports `compact`, `standard`, and `full` context loading modes
+  - Reports estimated token reduction using deterministic source-vs-handoff estimates
+- **Optional TDD test-case review checkpoint**:
+  - `sdd-init` and `sdd-tasks` can enable `reviewTestCases`
+  - New `sdd-review-test-cases` tool marks the checkpoint reviewed
+  - Task approval and implementation readiness are blocked until review when the checkpoint is required
+
+### Changed
+- **Default install profile is lean**: `npx sdd-mcp-server install` now installs skills, steering, and hooks by default
+  - Use `--profile full` or `--all` to install rules, contexts, and agents too
+- **Context management guidance**: README, architecture docs, and project steering now document compact handoffs and generated install outputs
+- **Generated install artifacts ignored**: `.claude/`, `.agents/`, and `.codex/` generated component outputs are excluded from new tracking
+
+### Fixed
+- **Context-load validation**: `sdd-context-load` now errors for missing features instead of creating synthetic handoff files for mistyped feature names
+- **Version metadata**: package lock metadata is synchronized with the published package version and current bin layout
+
 ## [3.3.0] - 2026-02-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A Model Context Protocol (MCP) server implementing Spec-Driven Development (SDD) workflows for AI-agent CLIs and IDEs like Claude Code, Cursor, and others.
 
-> **v3.3** - Multi-tool install support: `--codex` (AGENTS.md for OpenAI Codex CLI), `--antigravity` (.agent/ symlinks for Google Antigravity), `--all-tools`. See [CHANGELOG.md](CHANGELOG.md) for full version history.
+> **v3.4.0** - Automatic compact context handoffs, lean install defaults, and optional TDD test-case review checkpoints. See [CHANGELOG.md](CHANGELOG.md) for full version history.
 
 ## 🚀 Quick Start
 
@@ -16,7 +16,7 @@ A Model Context Protocol (MCP) server implementing Spec-Driven Development (SDD)
 npx -y sdd-mcp-server@latest
 
 # Pin exact version (optional)
-npx -y sdd-mcp-server@1.6.0
+npx -y sdd-mcp-server@3.4.0
 
 # For Claude Code MCP integration, add to your configuration:
 # "sdd-mcp-server": {
@@ -31,7 +31,7 @@ npx -y sdd-mcp-server@1.6.0
 npm install -g sdd-mcp-server@latest
 
 # Pin exact version (optional)
-npm install -g sdd-mcp-server@1.6.0
+npm install -g sdd-mcp-server@3.4.0
 
 # Start the server
 sdd-mcp-server
@@ -140,18 +140,21 @@ npm install -g sdd-mcp-server@latest
 sdd-mcp-server
 ```
 
-## 🎯 Agent Skills (NEW in v1.9.0)
+## 🎯 Agent Skills & Components (v3.4.0)
 
 SDD now uses a **hybrid architecture** for better token efficiency:
 
 - **MCP Tools**: Action-oriented operations (init, status, approve, quality-check, validate, spec-impl)
 - **Agent Skills**: Template/guidance-heavy operations (requirements, design, tasks, steering, implement, commit)
 
-### Installing Components (v3.0+)
+### Installing Components (v3.4.0)
 
 ```bash
-# Recommended: Install ALL components (skills, steering, rules, contexts, agents, hooks)
-npx sdd-mcp-server install --all
+# Recommended: lean install for lower token usage (skills, steering, hooks)
+npx sdd-mcp-server install
+
+# Full install when you explicitly want all always-on guidance components
+npx sdd-mcp-server install --profile full
 
 # Install specific component types
 npx sdd-mcp-server install --skills      # Skills to .claude/skills/
@@ -163,9 +166,6 @@ npx sdd-mcp-server install --hooks       # Hooks to .claude/hooks/
 
 # Install multiple component types
 npx sdd-mcp-server install --skills --rules --agents
-
-# Default: Install skills + steering (backward compatible)
-npx sdd-mcp-server install
 
 # List all available components
 npx sdd-mcp-server install --list
@@ -179,12 +179,12 @@ npx sdd-mcp-server install --antigravity       # + .agent/ symlinks for Google A
 npx sdd-mcp-server install --all-tools         # + all tool integrations
 ```
 
-**Component Types (v3.0):**
+**Component Types (v3.4.0):**
 | Component | Install Path | Purpose |
 |-----------|--------------|---------|
 | **Skills** | `.claude/skills/` | Workflow guidance (requirements, design, tasks, implement, etc.) |
 | **Steering** | `.spec/steering/` | Project-specific templates (product, tech, structure) |
-| **Rules** | `.claude/rules/` | Always-active guidelines (coding-style, testing, security, git-workflow) |
+| **Rules** | `.claude/rules/` | Optional always-active guidelines (coding-style, testing, security, git-workflow) |
 | **Contexts** | `.claude/contexts/` | Mode-specific prompts (dev, review, planning, security-audit, research) |
 | **Agents** | `.claude/agents/` | Specialized AI personas (planner, architect, reviewer, implementer) |
 | **Hooks** | `.claude/hooks/` | Event-driven automation (pre-tool-use, post-tool-use, session events) |
@@ -208,11 +208,12 @@ The 6 component types work together in a **layered guidance model**:
                               │
                               ▼
 ┌──────────────────────────────────────────────────────────────┐
-│  RULES (always active)                                       │
+│  RULES (optional always-active profile)                      │
 │  • coding-style.md → TypeScript/JS conventions               │
 │  • testing.md → TDD requirements                             │
 │  • security.md → OWASP guidelines                            │
-│  • Loaded at session start, apply to ALL operations          │
+│  • Install only when your client benefits from always-on     │
+│    rule files                                                │
 └──────────────────────────────────────────────────────────────┘
                               │
                               ▼
@@ -244,7 +245,7 @@ The 6 component types work together in a **layered guidance model**:
                               │
                               ▼
 ┌──────────────────────────────────────────────────────────────┐
-│  STEERING (project-specific templates - v3.1+)               │
+│  STEERING (project-specific templates - v3.4.0)              │
 │  • product.md → Product description                          │
 │  • tech.md → Technology stack                                │
 │  • structure.md → Project structure                          │
@@ -262,7 +263,7 @@ The 6 component types work together in a **layered guidance model**:
 **When Each Component Activates:**
 | Component | Activation | Example |
 |-----------|------------|---------|
-| **Rules** | Session start (always) | `coding-style.md` enforces conventions on every response |
+| **Rules** | Full profile/session start | `coding-style.md` enforces conventions when rules are installed |
 | **Contexts** | Task type detection | `review.md` activates when reviewing code |
 | **Agents** | Explicit invocation | `reviewer.md` invoked by `/sdd-review` skill |
 | **Skills** | User command (`/skill-name`) | `/sdd-requirements` loads requirements template |
@@ -329,8 +330,35 @@ After installation, use these skills in Claude Code:
 
 **Old Design** (static steering): ~3,800 tokens loaded for every operation
 **New Design** (skills): ~1,700 tokens loaded only when skill invoked
+**Lean Install** (default): avoids installing rules, contexts, and agents unless requested
+**Automatic Handoffs**: phase approvals write compact `.spec/specs/{feature}/context/handoff.md` summaries and `sdd-context-load` uses them by default
 
-**Savings**: ~55% fewer tokens in typical operations!
+**Savings**: ~55% fewer tokens in typical operations, with further savings from lean install and compact handoffs. On typical specs, compact handoff loading targets a 60-85% reduction versus loading full `requirements.md`, `design.md`, and `tasks.md`.
+
+### Automatic Context Handoffs
+
+To reduce context growth during long SDD workflows, approval tools automatically compact phase context:
+
+```text
+sdd-approve requirements  -> .spec/specs/{feature}/context/requirements-handoff.md
+sdd-approve design        -> .spec/specs/{feature}/context/design-handoff.md
+sdd-approve tasks         -> .spec/specs/{feature}/context/tasks-handoff.md
+latest approved context   -> .spec/specs/{feature}/context/handoff.md
+```
+
+`sdd-context-load` defaults to compact mode and loads `handoff.md` instead of all phase documents.
+
+Use explicit modes when needed:
+
+```json
+{ "featureName": "auth-flow", "mode": "compact" }
+{ "featureName": "auth-flow", "mode": "standard" }
+{ "featureName": "auth-flow", "mode": "full" }
+```
+
+- `compact`: handoff only, best for routine continuation.
+- `standard`: handoff plus current `spec.json`.
+- `full`: all phase documents, for audits or ambiguous decisions.
 
 ## 📋 Available MCP Tools
 
@@ -341,8 +369,9 @@ Once connected to your AI client, you can use these MCP tools:
 | `sdd-init` | Initialize new SDD project with interactive clarification | Analyzes description quality (0-100 score), blocks if < 70%, asks targeted WHY/WHO/WHAT questions |
 | `sdd-status` | Check workflow progress | Shows current phase and approvals for features |
 | `sdd-approve` | Approve workflow phases | Mark phases (requirements, design, tasks) as approved |
+| `sdd-review-test-cases` | Approve optional TDD test-case checkpoint | Use before approving tasks when test-case review is enabled |
 | `sdd-quality-check` | Code quality analysis | Linus-style 5-layer code review |
-| `sdd-context-load` | Load project context | Restore project memory and state |
+| `sdd-context-load` | Load project context | Defaults to compact handoff context; use `mode: "full"` only when needed |
 | `sdd-validate-design` | Design quality validation | Interactive GO/NO-GO design review |
 | `sdd-validate-gap` | Implementation gap analysis | Analyze requirements vs codebase |
 | `sdd-spec-impl` | Execute tasks with TDD | Kent Beck's Red-Green-Refactor methodology |
@@ -385,6 +414,8 @@ Once connected to your AI client, you can use these MCP tools:
    Use /sdd-tasks <feature-name> to create TDD-focused task breakdown
    Includes test pyramid guidance (70/20/10 ratio)
    Tasks follow RED-GREEN-REFACTOR workflow automatically
+   Optional: enable test-case review checkpoint before implementation
+   If enabled, run sdd-review-test-cases before approving tasks
    Use sdd-approve (MCP tool) to approve the tasks phase
    ```
 
@@ -404,7 +435,7 @@ Once connected to your AI client, you can use these MCP tools:
 7. **Monitor & Manage (MCP Tools)**
    ```
    Use sdd-status to check workflow progress and phase approvals
-   Use sdd-context-load to restore project memory
+   Use sdd-context-load to restore compact project memory
    ```
 
 ## ⚙️ Configuration
@@ -480,7 +511,7 @@ claude mcp add sdd "sdd-mcp-server"
 - **EARS-Formatted Requirements**: Generate acceptance criteria based on actual npm scripts and dependencies
 - **Quality Enforcement**: Linus-style 5-layer code review system with security (OWASP Top 10) checks
 
-### Plugin Architecture (v3.0)
+### Plugin Architecture (v3.4.0)
 - **6 Component Types**: Skills, Steering, Rules, Contexts, Agents, Hooks for comprehensive AI guidance
 - **Specialized Agents**: Planner, Architect, Reviewer, Implementer, Security-Auditor, TDD-Guide personas
 - **Always-Active Rules**: Coding-style, Testing, Security, Git-workflow, Error-handling enforcement
@@ -496,7 +527,7 @@ claude mcp add sdd "sdd-mcp-server"
 
 ### Guidelines & Standards
 - **Coding Principles Enforcement**: Built-in SOLID, DRY, KISS, YAGNI, Separation of Concerns, and Modularity guidance
-- **Comprehensive Steering Documents**: 8 auto-generated guidance docs (product, tech, structure, linus-review, commit, tdd-guideline, security-check, principles)
+- **Project Steering Documents**: Project-specific `product.md`, `tech.md`, and `structure.md` docs, with static guidance consolidated into installable skills/rules/agents
 - **Multi-Language Support**: 10 languages with cultural adaptation (en, es, fr, de, it, pt, ru, ja, zh, ko)
 - **Template Engine**: Handlebars-based file generation with project-specific data
 - **Plugin System**: Extensible architecture for custom workflows
@@ -512,8 +543,8 @@ Here's how to use the MCP SDD Server in your AI client:
  for a React/TypeScript application with user authentication"
 
 # 2. Generate steering documents
-"Use sdd-steering to analyze my codebase and generate all steering documents"
-# Result: 8 steering documents created including principles.md and tdd-guideline.md
+"Use /sdd-steering to analyze my codebase and update project steering documents"
+# Result: product.md, tech.md, and structure.md describe your project
 
 # 3. Generate requirements with comprehensive analysis
 "Use sdd-requirements to analyze the project and create requirements.md"
@@ -533,7 +564,7 @@ Here's how to use the MCP SDD Server in your AI client:
 
 # 7. Implement with TDD
 "Use sdd-spec-impl to execute the authentication tasks with TDD methodology"
-# Result: Test-first development following principles.md and tdd-guideline.md
+# Result: Test-first development using installed skill and agent guidance
 
 # 8. Review code quality
 "Use sdd-quality-check to perform Linus-style code review with SOLID principles check"
@@ -630,15 +661,15 @@ For detailed documentation on:
 - **Plugin Development**: See [DEPLOYMENT.md](DEPLOYMENT.md)
 - **Docker Deployment**: See [Dockerfile](Dockerfile) and [docker-compose.yml](docker-compose.yml)
 
-**Component Documentation (v3.0)**:
+**Component Documentation (v3.4.0)**:
 - **Rules**: See `rules/*.md` for always-active coding guidelines
 - **Contexts**: See `contexts/*.md` for mode-specific system prompts
 - **Agents**: See `agents/*.md` for specialized AI personas
 - **Hooks**: See `hooks/**/*.md` for event-driven automation
 
-**Steering Documents (v3.1+)**:
+**Steering Documents (v3.4.0)**:
 
-As of v3.1, static steering content has been consolidated into enhanced components:
+Static steering content has been consolidated into enhanced components:
 - **Design Principles**: `.claude/rules/coding-style.md` (includes SOLID, DRY, KISS, YAGNI, SoC)
 - **TDD Methodology**: `.claude/agents/tdd-guide.md` (Red-Green-Refactor workflow)
 - **Code Review**: `.claude/agents/reviewer.md` (Linus-style 5-layer thinking)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sdd-mcp-server",
-  "version": "2.1.0",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sdd-mcp-server",
-      "version": "2.1.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.4",
@@ -29,8 +29,7 @@
       },
       "bin": {
         "sdd-install-skills": "dist/cli/install-skills.js",
-        "sdd-mcp": "dist/cli/sdd-mcp-cli.js",
-        "sdd-mcp-server": "mcp-server.js"
+        "sdd-mcp-server": "sdd-entry.js"
       },
       "devDependencies": {
         "@types/esprima": "^4.0.6",
@@ -82,7 +81,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1937,7 +1935,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -2287,7 +2284,6 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2607,7 +2603,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -3232,7 +3227,6 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3505,7 +3499,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -4432,7 +4425,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5824,8 +5816,7 @@
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
-      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "peer": true
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -6574,7 +6565,6 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6811,7 +6801,6 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sdd-mcp-server",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "MCP server for spec-driven development workflows across AI-agent CLIs and IDEs",
   "main": "dist/index.js",
   "bin": {

--- a/skills/sdd-implement/SKILL.md
+++ b/skills/sdd-implement/SKILL.md
@@ -11,16 +11,18 @@ Execute implementation following TDD methodology, SOLID principles, and security
 
 Before implementing:
 1. Tasks must be approved (use `sdd-status` to verify)
-2. Review tasks in `.spec/specs/{feature}/tasks.md`
-3. Understand the design in `.spec/specs/{feature}/design.md`
+2. If the TDD test-case review checkpoint is enabled, test cases must be reviewed first (`sdd-review-test-cases`)
+3. Review tasks in `.spec/specs/{feature}/tasks.md`
+4. Understand the design in `.spec/specs/{feature}/design.md`
 
 ## Implementation Workflow
 
 ### Step 1: Load Context
 
 1. Use `sdd-status` MCP tool to verify all phases approved
-2. Read the tasks document for current implementation
-3. Identify the next task to implement
+2. Confirm `TDD Test Case Review` is reviewed when that checkpoint appears in status
+3. Read the tasks document for current implementation
+4. Identify the next task to implement
 
 ### Step 2: Execute TDD Cycle
 

--- a/skills/sdd-tasks/SKILL.md
+++ b/skills/sdd-tasks/SKILL.md
@@ -52,7 +52,17 @@ For each task, follow the Red-Green-Refactor cycle:
 └─────────────────────────────────────────────────────────────┘
 ```
 
-### Step 4: Apply Test Pyramid
+### Step 4: Choose Test Case Review Checkpoint
+
+Ask the user whether they want to review TDD test cases before implementation:
+
+- If yes, enable the checkpoint when generating tasks by setting `reviewTestCases: true` where the MCP tool supports it, or record the choice in `spec.json` under `workflow_options.review_test_cases`.
+- Generate a concise **Test Case Review Checklist** in `tasks.md` listing the behavior, edge, and error scenarios that need approval.
+- Before approving tasks, the user or agent should run `sdd-review-test-cases` after reviewing the test cases.
+
+Keep this checkpoint optional. If the user declines, continue with normal task approval.
+
+### Step 5: Apply Test Pyramid
 
 Structure tests following the 70/20/10 ratio:
 
@@ -75,7 +85,7 @@ Structure tests following the 70/20/10 ratio:
 | **Integration** | 20% | Component interactions | Medium (s) |
 | **E2E** | 10% | Full user journeys | Slow (min) |
 
-### Step 5: Generate Task Breakdown
+### Step 6: Generate Task Breakdown
 
 Structure tasks hierarchically:
 
@@ -131,11 +141,12 @@ Structure tasks hierarchically:
 - [ ] All tests pass
 - [ ] Code coverage >= 80%
 - [ ] No lint/type errors
+- [ ] TDD test cases reviewed (if checkpoint enabled)
 - [ ] Code reviewed
 - [ ] Documentation updated
 ```
 
-### Step 6: Task Sizing Guidelines
+### Step 7: Task Sizing Guidelines
 
 | Size | Description | Test Count | Time |
 |------|-------------|------------|------|
@@ -144,7 +155,7 @@ Structure tasks hierarchically:
 | **L** | Component with integration | 5-10 | 4-8 hours |
 | **XL** | Complex component, many edge cases | 10+ | 1-2 days |
 
-### Step 7: Test-First Task Template
+### Step 8: Test-First Task Template
 
 For each implementation task:
 
@@ -196,17 +207,19 @@ describe('{Component}', () => {
 - Apply {specific pattern}
 ```
 
-### Step 8: Save and Execute
+### Step 9: Save and Execute
 
 1. Save tasks to `.spec/specs/{feature}/tasks.md`
-2. Use `sdd-approve tasks` MCP tool to mark phase complete
-3. Use `sdd-spec-impl` MCP tool to execute tasks with TDD
+2. If test-case review is enabled, review the Test Case Review Checklist and run `sdd-review-test-cases`
+3. Use `sdd-approve tasks` MCP tool to mark phase complete
+4. Use `sdd-spec-impl` MCP tool to execute tasks with TDD
 
 ## MCP Tool Integration
 
 | Tool | When to Use |
 |------|-------------|
 | `sdd-status` | Verify design phase complete |
+| `sdd-review-test-cases` | Mark optional TDD test-case review complete |
 | `sdd-approve` | Mark tasks phase as approved |
 | `sdd-spec-impl` | Execute tasks using TDD methodology |
 | `sdd-quality-check` | Validate code quality during implementation |

--- a/src/__tests__/unit/cli/install-skills.test.ts
+++ b/src/__tests__/unit/cli/install-skills.test.ts
@@ -35,6 +35,7 @@ function createOptions(overrides: Partial<CLIOptions> = {}): CLIOptions {
     codex: false,
     antigravity: false,
     allTools: false,
+    installProfile: 'lean',
     ...overrides,
   };
 }
@@ -101,6 +102,7 @@ describe('InstallSkillsCLI', () => {
       expect(options.contextsPath).toBe('.claude/contexts');
       expect(options.agentsPath).toBe('.claude/agents');
       expect(options.hooksPath).toBe('.claude/hooks');
+      expect(options.installProfile).toBe('lean');
     });
 
     it('should parse --list flag', () => {
@@ -198,7 +200,15 @@ describe('InstallSkillsCLI', () => {
       const args = ['--all'];
       const options = cli.parseArgs(args);
 
+      expect(options.installProfile).toBe('full');
       expect(options.components).toEqual(['skills', 'steering', 'rules', 'contexts', 'agents', 'hooks']);
+    });
+
+    it('should parse --profile full flag', () => {
+      const args = ['--profile', 'full'];
+      const options = cli.parseArgs(args);
+
+      expect(options.installProfile).toBe('full');
     });
 
     it('should parse multiple component flags', () => {

--- a/src/__tests__/unit/context/ContextCompactionService.test.ts
+++ b/src/__tests__/unit/context/ContextCompactionService.test.ts
@@ -1,0 +1,148 @@
+import { mkdtemp, readFile, rm, mkdir, writeFile, readdir, stat } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { ContextCompactionService } from '../../../application/services/ContextCompactionService';
+import { FileSystemPort, LoggerPort } from '../../../domain/ports';
+import { Project, WorkflowPhase } from '../../../domain/types';
+
+class NodeTestFileSystem implements FileSystemPort {
+  readFile(filePath: string): Promise<string> {
+    return readFile(filePath, 'utf8');
+  }
+
+  writeFile(filePath: string, content: string): Promise<void> {
+    return writeFile(filePath, content, 'utf8');
+  }
+
+  async exists(filePath: string): Promise<boolean> {
+    try {
+      await stat(filePath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  mkdir(dirPath: string): Promise<void> {
+    return mkdir(dirPath, { recursive: true }).then(() => undefined);
+  }
+
+  readdir(dirPath: string): Promise<string[]> {
+    return readdir(dirPath);
+  }
+
+  stat(filePath: string): Promise<{ isFile(): boolean; isDirectory(): boolean }> {
+    return stat(filePath);
+  }
+}
+
+const logger: LoggerPort = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn()
+};
+
+function createProject(projectRoot: string): Project {
+  return {
+    id: 'project-1',
+    name: 'auth-flow',
+    path: projectRoot,
+    phase: WorkflowPhase.TASKS,
+    metadata: {
+      createdAt: new Date('2026-06-21T00:00:00.000Z'),
+      updatedAt: new Date('2026-06-21T00:00:00.000Z'),
+      language: 'en',
+      approvals: {
+        requirements: { generated: true, approved: true },
+        design: { generated: true, approved: true },
+        tasks: { generated: true, approved: true }
+      },
+      workflowOptions: { reviewTestCases: true },
+      checkpoints: {
+        testCases: { required: true, reviewed: true }
+      }
+    }
+  };
+}
+
+describe('ContextCompactionService', () => {
+  let projectRoot: string;
+  let service: ContextCompactionService;
+  let project: Project;
+
+  beforeEach(async () => {
+    projectRoot = await mkdtemp(path.join(os.tmpdir(), 'sdd-context-'));
+    project = createProject(projectRoot);
+    const specDir = path.join(projectRoot, '.spec', 'specs', project.name);
+    await mkdir(specDir, { recursive: true });
+    await writeFile(
+      path.join(specDir, 'requirements.md'),
+      `# Requirements Document
+
+## Functional Requirements
+- User MUST be able to sign in with valid credentials.
+- WHEN credentials are invalid THEN the system SHALL reject access.
+
+## Non-Functional Requirements
+- Security controls MUST avoid leaking authentication state.
+`.repeat(8),
+      'utf8'
+    );
+    await writeFile(
+      path.join(specDir, 'design.md'),
+      `# Technical Design
+
+## Architecture
+- AuthService validates credentials.
+- SessionRepository stores session metadata.
+
+## Risks
+- Token expiration MUST be deterministic.
+`.repeat(8),
+      'utf8'
+    );
+    await writeFile(
+      path.join(specDir, 'tasks.md'),
+      `# Tasks
+
+- [ ] 1. Write failing tests for valid sign-in.
+- [ ] 2. Implement minimal AuthService.
+- [ ] 3. Refactor session handling.
+`.repeat(8),
+      'utf8'
+    );
+
+    service = new ContextCompactionService(new NodeTestFileSystem(), logger);
+  });
+
+  afterEach(async () => {
+    await rm(projectRoot, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  it('generates compact handoff files after phase approval', async () => {
+    const result = await service.generatePhaseHandoff(project, 'tasks');
+
+    expect(result.path).toBe(path.join(projectRoot, '.spec', 'specs', project.name, 'context', 'handoff.md'));
+    expect(result.content).toContain('SDD Context Handoff: auth-flow');
+    expect(result.content).toContain('TDD test-case review: reviewed');
+    expect(result.estimate.reductionPercentage).toBeGreaterThan(40);
+
+    const persisted = await readFile(result.path, 'utf8');
+    expect(persisted).toContain('Context Budget Estimate');
+    await expect(readFile(path.join(projectRoot, '.spec', 'specs', project.name, 'context', 'tasks-handoff.md'), 'utf8'))
+      .resolves.toContain('Approved phase: tasks');
+  });
+
+  it('loads compact handoff by default and full context only when requested', async () => {
+    await service.generatePhaseHandoff(project, 'tasks');
+
+    const compact = await service.loadContext(project);
+    const full = await service.loadContext(project, 'full');
+
+    expect(compact).toContain('Compact Phase Summaries');
+    expect(full).toContain('Full SDD Context');
+    expect(compact.length).toBeLessThan(full.length);
+  });
+});

--- a/src/__tests__/unit/workflow/TestCaseReviewCheckpoint.test.ts
+++ b/src/__tests__/unit/workflow/TestCaseReviewCheckpoint.test.ts
@@ -1,0 +1,74 @@
+import { WorkflowDomainService } from '../../../domain/services/DomainService';
+import { WorkflowPhase, Project } from '../../../domain/types';
+import { AjvValidationAdapter } from '../../../infrastructure/adapters/AjvValidationAdapter';
+import { projectSchema } from '../../../infrastructure/schemas/project.schema';
+
+function createReadyProject(checkpoint: { required: boolean; reviewed: boolean }): Project {
+  return {
+    id: 'project-1',
+    name: 'checkout-flow',
+    path: '/tmp/checkout-flow',
+    phase: WorkflowPhase.TASKS,
+    metadata: {
+      createdAt: new Date('2026-06-21T00:00:00.000Z'),
+      updatedAt: new Date('2026-06-21T00:00:00.000Z'),
+      language: 'en',
+      approvals: {
+        requirements: { generated: true, approved: true },
+        design: { generated: true, approved: true },
+        tasks: { generated: true, approved: true }
+      },
+      workflowOptions: {
+        reviewTestCases: checkpoint.required
+      },
+      checkpoints: {
+        testCases: checkpoint
+      }
+    }
+  };
+}
+
+describe('TDD test-case review checkpoint', () => {
+  it('blocks implementation readiness when review is required but not completed', () => {
+    const project = createReadyProject({ required: true, reviewed: false });
+
+    expect(WorkflowDomainService.isReadyForImplementation(project)).toBe(false);
+    expect(
+      WorkflowDomainService.canTransitionToPhase(project, WorkflowPhase.IMPLEMENTATION)
+    ).toBe(false);
+    expect(
+      WorkflowDomainService.getRequiredApprovals(project, WorkflowPhase.IMPLEMENTATION)
+    ).toContain('test-cases');
+  });
+
+  it('does not block implementation when the review checkpoint is disabled', () => {
+    const project = createReadyProject({ required: false, reviewed: true });
+
+    expect(WorkflowDomainService.isReadyForImplementation(project)).toBe(true);
+  });
+
+  it('allows implementation when required review is completed', () => {
+    const project = createReadyProject({ required: true, reviewed: true });
+
+    expect(WorkflowDomainService.isReadyForImplementation(project)).toBe(true);
+  });
+
+  it('validates checkpoint metadata with in-memory Date values', async () => {
+    const project = {
+      ...createReadyProject({ required: true, reviewed: true }),
+      metadata: {
+        ...createReadyProject({ required: true, reviewed: true }).metadata,
+        checkpoints: {
+          testCases: {
+            required: true,
+            reviewed: true,
+            reviewedAt: new Date('2026-06-21T00:00:00.000Z')
+          }
+        }
+      }
+    };
+    const validator = new AjvValidationAdapter();
+
+    await expect(validator.validate(project, projectSchema)).resolves.toEqual(project);
+  });
+});

--- a/src/adapters/cli/SDDToolAdapter.ts
+++ b/src/adapters/cli/SDDToolAdapter.ts
@@ -10,6 +10,7 @@ import { QualityService } from "../../application/services/QualityService.js";
 import { SteeringDocumentService } from "../../application/services/SteeringDocumentService.js";
 import { CodebaseAnalysisService } from "../../application/services/CodebaseAnalysisService.js";
 import { RequirementsClarificationService } from "../../application/services/RequirementsClarificationService.js";
+import { ContextCompactionService, ContextLoadMode } from "../../application/services/ContextCompactionService.js";
 import { LoggerPort } from "../../domain/ports.js";
 import { WorkflowPhase, ClarificationAnswers } from "../../domain/types.js";
 import { ensureStaticSteeringDocuments } from "../../application/services/staticSteering.js";
@@ -37,6 +38,8 @@ export class SDDToolAdapter {
     private readonly codebaseAnalysisService: CodebaseAnalysisService,
     @inject(TYPES.RequirementsClarificationService)
     private readonly clarificationService: RequirementsClarificationService,
+    @inject(TYPES.ContextCompactionService)
+    private readonly contextCompactionService: ContextCompactionService,
     @inject(TYPES.LoggerPort) private readonly logger: LoggerPort,
   ) { }
 
@@ -63,6 +66,11 @@ export class SDDToolAdapter {
                 type: "object",
                 description: "Answers to clarification questions (second pass)",
                 additionalProperties: { type: "string" },
+              },
+              reviewTestCases: {
+                type: "boolean",
+                description:
+                  "Enable an optional checkpoint requiring TDD test-case review before implementation",
               },
             },
             required: ["projectName"],
@@ -97,9 +105,9 @@ export class SDDToolAdapter {
           inputSchema: {
             type: "object",
             properties: {
-              featureName: { type: "string", description: "Feature name" },
+              projectId: { type: "string", description: "Project ID" },
             },
-            required: ["featureName"],
+            required: ["projectId"],
           },
         },
         handler: this.handleRequirements.bind(this),
@@ -112,9 +120,9 @@ export class SDDToolAdapter {
           inputSchema: {
             type: "object",
             properties: {
-              featureName: { type: "string", description: "Feature name" },
+              projectId: { type: "string", description: "Project ID" },
             },
-            required: ["featureName"],
+            required: ["projectId"],
           },
         },
         handler: this.handleDesign.bind(this),
@@ -127,12 +135,33 @@ export class SDDToolAdapter {
           inputSchema: {
             type: "object",
             properties: {
-              featureName: { type: "string", description: "Feature name" },
+              projectId: { type: "string", description: "Project ID" },
+              reviewTestCases: {
+                type: "boolean",
+                description:
+                  "When true, require an explicit TDD test-case review checkpoint before implementation",
+              },
             },
-            required: ["featureName"],
+            required: ["projectId"],
           },
         },
         handler: this.handleTasks.bind(this),
+      },
+      {
+        name: "sdd-review-test-cases",
+        tool: {
+          name: "sdd-review-test-cases",
+          description:
+            "Mark the optional TDD test-case review checkpoint as reviewed",
+          inputSchema: {
+            type: "object",
+            properties: {
+              projectId: { type: "string", description: "Project ID" },
+            },
+            required: ["projectId"],
+          },
+        },
+        handler: this.handleReviewTestCases.bind(this),
       },
       {
         name: "sdd-quality-check",
@@ -149,6 +178,28 @@ export class SDDToolAdapter {
           },
         },
         handler: this.handleQualityCheck.bind(this),
+      },
+      {
+        name: "sdd-context-load",
+        tool: {
+          name: "sdd-context-load",
+          description:
+            "Load compact workflow handoff context by default; use mode=full only when necessary",
+          inputSchema: {
+            type: "object",
+            properties: {
+              projectId: { type: "string", description: "Project ID" },
+              mode: {
+                type: "string",
+                enum: ["compact", "standard", "full"],
+                description:
+                  "Context size mode. compact is default and uses handoff.md.",
+              },
+            },
+            required: ["projectId"],
+          },
+        },
+        handler: this.handleContextLoad.bind(this),
       },
       {
         name: "sdd-steering",
@@ -208,7 +259,12 @@ export class SDDToolAdapter {
   private async handleProjectInit(
     args: Record<string, unknown>,
   ): Promise<string> {
-    const { projectName, description = "", clarificationAnswers } = args;
+    const {
+      projectName,
+      description = "",
+      clarificationAnswers,
+      reviewTestCases = false,
+    } = args;
 
     if (typeof projectName !== "string") {
       throw new Error("Invalid arguments: projectName must be a string");
@@ -267,6 +323,7 @@ export class SDDToolAdapter {
       projectName,
       currentPath,
       "en",
+      { reviewTestCases: reviewTestCases === true },
     );
 
     // Generate initial spec.json
@@ -341,6 +398,10 @@ export class SDDToolAdapter {
     output += `Current Phase: ${status.currentPhase}\n`;
     output += `Next Phase: ${status.nextPhase ?? "Complete"}\n`;
     output += `Can Progress: ${status.canProgress ? "Yes" : "No"}\n`;
+    const testCaseCheckpoint = project.metadata.checkpoints?.testCases;
+    if (testCaseCheckpoint?.required) {
+      output += `TDD Test Cases Reviewed: ${testCaseCheckpoint.reviewed ? "Yes" : "No"}\n`;
+    }
 
     if (status.blockers && status.blockers.length > 0) {
       output += `Blockers:\n`;
@@ -390,10 +451,12 @@ export class SDDToolAdapter {
       projectId,
       WorkflowPhase.REQUIREMENTS,
     );
-    await this.projectService.updateApprovalStatus(projectId, "requirements", {
+    const updatedProject = await this.projectService.updateApprovalStatus(projectId, "requirements", {
       generated: true,
       approved: false,
     });
+    const specContent = await this.templateService.generateSpecJson(updatedProject);
+    await this.templateService.writeProjectFile(updatedProject, "spec.json", specContent);
 
     return `Requirements document generated for project "${project.name}"`;
   }
@@ -429,16 +492,18 @@ export class SDDToolAdapter {
       projectId,
       WorkflowPhase.DESIGN,
     );
-    await this.projectService.updateApprovalStatus(projectId, "design", {
+    const updatedProject = await this.projectService.updateApprovalStatus(projectId, "design", {
       generated: true,
       approved: false,
     });
+    const specContent = await this.templateService.generateSpecJson(updatedProject);
+    await this.templateService.writeProjectFile(updatedProject, "spec.json", specContent);
 
     return `Design document generated for project "${project.name}"`;
   }
 
   private async handleTasks(args: Record<string, unknown>): Promise<string> {
-    const { projectId } = args;
+    const { projectId, reviewTestCases } = args;
 
     if (typeof projectId !== "string") {
       throw new Error("Invalid argument: projectId must be a string");
@@ -463,17 +528,50 @@ export class SDDToolAdapter {
     const content = await this.templateService.generateTasksTemplate(project);
     await this.templateService.writeProjectFile(project, "tasks.md", content);
 
+    if (typeof reviewTestCases === "boolean") {
+      await this.projectService.updateTestCaseReviewCheckpoint(projectId, {
+        required: reviewTestCases,
+        reviewed: !reviewTestCases,
+      });
+    }
+
     // Update project phase and approval status
     await this.projectService.updateProjectPhase(
       projectId,
       WorkflowPhase.TASKS,
     );
-    await this.projectService.updateApprovalStatus(projectId, "tasks", {
+    const updatedProject = await this.projectService.updateApprovalStatus(projectId, "tasks", {
       generated: true,
       approved: false,
     });
+    const specContent = await this.templateService.generateSpecJson(updatedProject);
+    await this.templateService.writeProjectFile(updatedProject, "spec.json", specContent);
 
     return `Tasks document generated for project "${project.name}"`;
+  }
+
+  private async handleReviewTestCases(
+    args: Record<string, unknown>,
+  ): Promise<string> {
+    const { projectId } = args;
+
+    if (typeof projectId !== "string") {
+      throw new Error("Invalid argument: projectId must be a string");
+    }
+
+    const project = await this.projectService.getProject(projectId);
+    if (!project) {
+      throw new Error("Project not found");
+    }
+
+    const updatedProject = await this.projectService.updateTestCaseReviewCheckpoint(
+      projectId,
+      { required: true, reviewed: true },
+    );
+    const specContent = await this.templateService.generateSpecJson(updatedProject);
+    await this.templateService.writeProjectFile(updatedProject, "spec.json", specContent);
+
+    return `TDD test cases reviewed for project "${project.name}"`;
   }
 
   private async handleQualityCheck(
@@ -491,6 +589,31 @@ export class SDDToolAdapter {
     });
 
     return this.qualityService.formatQualityReport(report);
+  }
+
+  private async handleContextLoad(
+    args: Record<string, unknown>,
+  ): Promise<string> {
+    const { projectId, mode = "compact" } = args;
+
+    if (typeof projectId !== "string") {
+      throw new Error("Invalid argument: projectId must be a string");
+    }
+    if (!["compact", "standard", "full"].includes(mode as string)) {
+      throw new Error("Invalid argument: mode must be compact, standard, or full");
+    }
+
+    const project = await this.projectService.getProject(projectId);
+    if (!project) {
+      throw new Error("Project not found");
+    }
+
+    const context = await this.contextCompactionService.loadContext(
+      project,
+      mode as ContextLoadMode,
+    );
+
+    return context;
   }
 
   private async handleSteering(args: Record<string, unknown>): Promise<string> {

--- a/src/application/services/ContextCompactionService.ts
+++ b/src/application/services/ContextCompactionService.ts
@@ -1,0 +1,311 @@
+import { injectable, inject } from 'inversify';
+import { v4 as uuidv4 } from 'uuid';
+import { TYPES } from '../../infrastructure/di/types.js';
+import { FileSystemPort, LoggerPort } from '../../domain/ports.js';
+import { PhaseApprovals, Project } from '../../domain/types.js';
+
+export type ContextLoadMode = 'compact' | 'standard' | 'full';
+export type ApprovablePhase = keyof PhaseApprovals;
+
+interface DocumentSnapshot {
+  readonly name: string;
+  readonly path: string;
+  readonly content: string;
+}
+
+export interface ContextSizeEstimate {
+  readonly sourceCharacters: number;
+  readonly sourceTokens: number;
+  readonly compactCharacters: number;
+  readonly compactTokens: number;
+  readonly reductionPercentage: number;
+}
+
+export interface HandoffResult {
+  readonly path: string;
+  readonly content: string;
+  readonly estimate: ContextSizeEstimate;
+}
+
+@injectable()
+export class ContextCompactionService {
+  constructor(
+    @inject(TYPES.FileSystemPort) private readonly fileSystem: FileSystemPort,
+    @inject(TYPES.LoggerPort) private readonly logger: LoggerPort
+  ) {}
+
+  async generatePhaseHandoff(
+    project: Project,
+    approvedPhase: ApprovablePhase
+  ): Promise<HandoffResult> {
+    const correlationId = uuidv4();
+    const contextDir = this.getContextDir(project);
+    const handoffPath = `${contextDir}/handoff.md`;
+    const phaseHandoffPath = `${contextDir}/${approvedPhase}-handoff.md`;
+
+    this.logger.info('Generating compact workflow handoff', {
+      correlationId,
+      projectId: project.id,
+      approvedPhase
+    });
+
+    await this.fileSystem.mkdir(contextDir);
+
+    const documents = await this.loadAvailableDocuments(project);
+    const sourceCharacters = documents.reduce((sum, doc) => sum + doc.content.length, 0);
+    const content = this.buildHandoff(project, approvedPhase, documents, sourceCharacters);
+
+    await this.fileSystem.writeFile(handoffPath, content);
+    await this.fileSystem.writeFile(phaseHandoffPath, content);
+
+    const estimate = this.estimateContextSize(sourceCharacters, content.length);
+
+    this.logger.info('Compact workflow handoff generated', {
+      correlationId,
+      projectId: project.id,
+      approvedPhase,
+      sourceTokens: estimate.sourceTokens,
+      compactTokens: estimate.compactTokens,
+      reductionPercentage: estimate.reductionPercentage
+    });
+
+    return {
+      path: handoffPath,
+      content,
+      estimate
+    };
+  }
+
+  async loadContext(
+    project: Project,
+    mode: ContextLoadMode = 'compact'
+  ): Promise<string> {
+    if (mode === 'full') {
+      return this.loadFullContext(project);
+    }
+
+    const handoffPath = `${this.getContextDir(project)}/handoff.md`;
+    if (await this.fileSystem.exists(handoffPath)) {
+      const handoff = await this.fileSystem.readFile(handoffPath);
+
+      if (mode === 'standard') {
+        const spec = await this.readOptionalFile(`${this.getSpecDir(project)}/spec.json`);
+        return [
+          handoff,
+          spec ? '\n## Current Spec Metadata\n\n```json\n' + spec + '\n```' : ''
+        ].filter(Boolean).join('\n');
+      }
+
+      return handoff;
+    }
+
+    const documents = await this.loadAvailableDocuments(project);
+    const sourceCharacters = documents.reduce((sum, doc) => sum + doc.content.length, 0);
+    return this.buildHandoff(project, 'requirements', documents, sourceCharacters);
+  }
+
+  estimateContextSize(sourceCharacters: number, compactCharacters: number): ContextSizeEstimate {
+    const sourceTokens = this.estimateTokens(sourceCharacters);
+    const compactTokens = this.estimateTokens(compactCharacters);
+    const reductionPercentage = sourceTokens === 0
+      ? 0
+      : Math.max(0, Math.round((1 - compactTokens / sourceTokens) * 100));
+
+    return {
+      sourceCharacters,
+      sourceTokens,
+      compactCharacters,
+      compactTokens,
+      reductionPercentage
+    };
+  }
+
+  private async loadFullContext(project: Project): Promise<string> {
+    const documents = await this.loadAvailableDocuments(project);
+    const sections = documents.map((doc) => `## ${doc.name}\n\n${doc.content}`);
+    return [`# Full SDD Context: ${project.name}`, ...sections].join('\n\n');
+  }
+
+  private buildHandoff(
+    project: Project,
+    approvedPhase: ApprovablePhase,
+    documents: DocumentSnapshot[],
+    sourceCharacters: number
+  ): string {
+    const sourceTokens = this.estimateTokens(sourceCharacters);
+    const sections = documents.map((doc) => this.summarizeDocument(doc));
+    const approvals = project.metadata.approvals;
+    const checkpoint = project.metadata.checkpoints?.testCases;
+    const nextSteps = this.getNextSteps(approvedPhase, checkpoint?.required === true && !checkpoint.reviewed);
+
+    const draft = [
+      `# SDD Context Handoff: ${project.name}`,
+      '',
+      `Generated: ${new Date().toISOString()}`,
+      `Approved phase: ${approvedPhase}`,
+      '',
+      '## Workflow State',
+      '',
+      `- Requirements: ${this.formatApproval(approvals.requirements)}`,
+      `- Design: ${this.formatApproval(approvals.design)}`,
+      `- Tasks: ${this.formatApproval(approvals.tasks)}`,
+      checkpoint?.required
+        ? `- TDD test-case review: ${checkpoint.reviewed ? 'reviewed' : 'pending'}`
+        : '- TDD test-case review: not required',
+      '',
+      '## Compact Phase Summaries',
+      '',
+      sections.join('\n\n'),
+      '',
+      '## Next Actions',
+      '',
+      ...nextSteps.map((step) => `- ${step}`),
+      '',
+      '## Source References',
+      '',
+      ...documents.map((doc) => `- ${doc.path}`),
+      '',
+      '## Context Budget Estimate',
+      '',
+      `- Full source context: ~${sourceTokens} tokens`,
+      `- Handoff context: ~${this.estimateTokens(sourceCharacters > 0 ? Math.min(sourceCharacters, 1) : 0)} tokens before final write estimate`,
+      '- Use `sdd-context-load` default compact mode for routine continuation.',
+      '- Use `sdd-context-load` with `mode: "full"` only for audits or ambiguous decisions.'
+    ].join('\n');
+
+    const estimate = this.estimateContextSize(sourceCharacters, draft.length);
+    return draft.replace(
+      /- Handoff context: ~\d+ tokens before final write estimate/,
+      `- Handoff context: ~${estimate.compactTokens} tokens`
+    );
+  }
+
+  private summarizeDocument(doc: DocumentSnapshot): string {
+    const lines = this.normalizeLines(doc.content);
+    const headings = this.extractHeadings(lines);
+    const bullets = this.extractBullets(lines);
+    const requirements = this.extractRequirementLikeLines(lines);
+
+    return [
+      `### ${doc.name}`,
+      '',
+      headings.length > 0 ? '**Key sections:**' : '',
+      ...headings.slice(0, 8).map((line) => `- ${line}`),
+      bullets.length > 0 ? '\n**Important points:**' : '',
+      ...bullets.slice(0, 8).map((line) => `- ${line}`),
+      requirements.length > 0 ? '\n**Constraints and acceptance signals:**' : '',
+      ...requirements.slice(0, 8).map((line) => `- ${line}`),
+      headings.length === 0 && bullets.length === 0 && requirements.length === 0
+        ? '- No structured summary points found; open source document if this phase is active.'
+        : ''
+    ].filter(Boolean).join('\n');
+  }
+
+  private async loadAvailableDocuments(project: Project): Promise<DocumentSnapshot[]> {
+    const specDir = this.getSpecDir(project);
+    const names = ['requirements.md', 'design.md', 'tasks.md', 'spec.json'];
+    const documents: DocumentSnapshot[] = [];
+
+    for (const name of names) {
+      const path = `${specDir}/${name}`;
+      const content = await this.readOptionalFile(path);
+      if (content) {
+        documents.push({ name, path, content });
+      }
+    }
+
+    return documents;
+  }
+
+  private async readOptionalFile(path: string): Promise<string | null> {
+    try {
+      if (!(await this.fileSystem.exists(path))) {
+        return null;
+      }
+      return await this.fileSystem.readFile(path);
+    } catch {
+      return null;
+    }
+  }
+
+  private normalizeLines(content: string): string[] {
+    return content
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith('```'));
+  }
+
+  private extractHeadings(lines: string[]): string[] {
+    return this.unique(lines
+      .filter((line) => /^#{1,4}\s+/.test(line))
+      .map((line) => line.replace(/^#{1,4}\s+/, '').trim()));
+  }
+
+  private extractBullets(lines: string[]): string[] {
+    return this.unique(lines
+      .filter((line) => /^[-*]\s+/.test(line) || /^\d+\.\s+/.test(line))
+      .map((line) => line.replace(/^[-*]\s+/, '').replace(/^\d+\.\s+/, '').trim())
+      .filter((line) => line.length > 0 && line.length <= 220));
+  }
+
+  private extractRequirementLikeLines(lines: string[]): string[] {
+    const keywords = /\b(SHALL|MUST|WHEN|IF|THEN|WHERE|constraint|risk|security|performance|error|edge case)\b/i;
+    return this.unique(lines
+      .filter((line) => keywords.test(line))
+      .map((line) => line.replace(/^[-*]\s+/, '').replace(/^\d+\.\s+/, '').trim())
+      .filter((line) => line.length <= 240));
+  }
+
+  private unique(lines: string[]): string[] {
+    const seen = new Set<string>();
+    const result: string[] = [];
+
+    for (const line of lines) {
+      const key = line.toLowerCase();
+      if (!seen.has(key)) {
+        seen.add(key);
+        result.push(line);
+      }
+    }
+
+    return result;
+  }
+
+  private getNextSteps(approvedPhase: ApprovablePhase, testReviewPending: boolean): string[] {
+    if (approvedPhase === 'requirements') {
+      return ['Generate or review design using the approved requirements handoff.'];
+    }
+
+    if (approvedPhase === 'design') {
+      return ['Generate TDD task breakdown from the approved design handoff.'];
+    }
+
+    if (testReviewPending) {
+      return ['Review TDD test cases, then run sdd-review-test-cases before approving tasks.'];
+    }
+
+    return ['Begin implementation with compact context loaded; open full docs only for ambiguous details.'];
+  }
+
+  private formatApproval(status: { generated: boolean; approved: boolean }): string {
+    if (status.generated && status.approved) {
+      return 'generated, approved';
+    }
+    if (status.generated) {
+      return 'generated, pending approval';
+    }
+    return 'not generated';
+  }
+
+  private estimateTokens(characters: number): number {
+    return Math.max(1, Math.ceil(characters / 4));
+  }
+
+  private getSpecDir(project: Project): string {
+    return `${project.path}/.spec/specs/${project.name}`;
+  }
+
+  private getContextDir(project: Project): string {
+    return `${this.getSpecDir(project)}/context`;
+  }
+}

--- a/src/application/services/ProjectService.ts
+++ b/src/application/services/ProjectService.ts
@@ -24,7 +24,12 @@ export class ProjectService {
     @inject(TYPES.LoggerPort) private readonly logger: LoggerPort
   ) {}
 
-  async createProject(name: string, path: string, language = 'en'): Promise<Project> {
+  async createProject(
+    name: string,
+    path: string,
+    language = 'en',
+    options: { reviewTestCases?: boolean } = {}
+  ): Promise<Project> {
     const correlationId = uuidv4();
     
     this.logger.info('Creating new project', {
@@ -47,6 +52,15 @@ export class ProjectService {
           requirements: { generated: false, approved: false },
           design: { generated: false, approved: false },
           tasks: { generated: false, approved: false }
+        },
+        workflowOptions: {
+          reviewTestCases: options.reviewTestCases ?? false
+        },
+        checkpoints: {
+          testCases: {
+            required: options.reviewTestCases ?? false,
+            reviewed: !(options.reviewTestCases ?? false)
+          }
         }
       }
     };
@@ -156,6 +170,63 @@ export class ProjectService {
       correlationId,
       projectId,
       phaseType
+    });
+
+    return updatedProject;
+  }
+
+  async updateTestCaseReviewCheckpoint(
+    projectId: string,
+    checkpoint: Partial<{ required: boolean; reviewed: boolean }>
+  ): Promise<Project> {
+    const correlationId = uuidv4();
+
+    this.logger.info('Updating test case review checkpoint', {
+      correlationId,
+      projectId,
+      checkpoint
+    });
+
+    const project = await this.projectRepository.findById(projectId);
+    if (!project) {
+      throw new Error(`Project not found: ${projectId}`);
+    }
+
+    const current = project.metadata.checkpoints?.testCases ?? {
+      required: false,
+      reviewed: true
+    };
+    const required = checkpoint.required ?? current.required;
+    const reviewed = checkpoint.reviewed ?? (required ? current.reviewed : true);
+
+    const updatedProject: Project = {
+      ...project,
+      metadata: {
+        ...project.metadata,
+        updatedAt: new Date(),
+        workflowOptions: {
+          ...project.metadata.workflowOptions,
+          reviewTestCases: required
+        },
+        checkpoints: {
+          ...project.metadata.checkpoints,
+          testCases: {
+            required,
+            reviewed,
+            reviewedAt: reviewed ? new Date() : undefined
+          }
+        }
+      }
+    };
+
+    await this.validation.validate(updatedProject, projectSchema);
+    await this.projectRepository.save(updatedProject);
+
+    this.logger.info('Test case review checkpoint updated successfully', {
+      correlationId,
+      projectId,
+      required,
+      reviewed
     });
 
     return updatedProject;

--- a/src/application/services/TemplateService.ts
+++ b/src/application/services/TemplateService.ts
@@ -18,6 +18,7 @@ import type {
 } from '../../domain/templates/index.js';
 import { TYPES } from '../../infrastructure/di/types.js';
 import { Project } from '../../domain/types.js';
+import { WorkflowDomainService } from '../../domain/services/DomainService.js';
 import { 
   TemplateEngine, 
   FileSystemPort
@@ -79,11 +80,36 @@ export class TemplateService {
       "approved": {{project.metadata.approvals.tasks.approved}}
     }
   },
+  "workflow_options": {
+    "review_test_cases": {{project.metadata.workflowOptions.reviewTestCases}}
+  },
+  "checkpoints": {
+    "test_cases": {
+      "required": {{project.metadata.checkpoints.testCases.required}},
+      "reviewed": {{project.metadata.checkpoints.testCases.reviewed}}
+    }
+  },
   "ready_for_implementation": {{isReadyForImplementation project}}
 }`;
 
+    const normalizedProject: Project = {
+      ...project,
+      metadata: {
+        ...project.metadata,
+        workflowOptions: project.metadata.workflowOptions ?? {
+          reviewTestCases: false
+        },
+        checkpoints: project.metadata.checkpoints ?? {
+          testCases: {
+            required: false,
+            reviewed: true
+          }
+        }
+      }
+    };
+
     const data: LegacyTemplateData = {
-      project,
+      project: normalizedProject,
       timestamp: new Date().toISOString()
     };
 
@@ -579,10 +605,7 @@ ${tasks.deployment.map((task, index) => `- [ ] ${index + 1}. ${task.title}
 
   private registerCustomHelpers(): void {
     this.templateEngine.registerHelper('isReadyForImplementation', (project: Project) => {
-      const { approvals } = project.metadata;
-      return (approvals.requirements.approved && 
-             approvals.design.approved && 
-             approvals.tasks.approved).toString();
+      return WorkflowDomainService.isReadyForImplementation(project).toString();
     });
 
     this.templateEngine.registerHelper('formatDate', (date: Date) => {

--- a/src/application/services/WorkflowEngineService.ts
+++ b/src/application/services/WorkflowEngineService.ts
@@ -17,6 +17,7 @@ import {
 } from '../../domain/workflow/WorkflowStateMachine.js';
 import { ProjectService } from './ProjectService.js';
 import { TemplateService } from './TemplateService.js';
+import { ContextCompactionService, HandoffResult } from './ContextCompactionService.js';
 
 export interface WorkflowProgressionResult {
   success: boolean;
@@ -41,6 +42,7 @@ export class WorkflowEngineService {
     @inject(TYPES.ProjectRepository) private readonly projectRepository: ProjectRepository,
     @inject(TYPES.ProjectService) private readonly projectService: ProjectService,
     @inject(TYPES.TemplateService) private readonly templateService: TemplateService,
+    @inject(TYPES.ContextCompactionService) private readonly contextCompactionService: ContextCompactionService,
     @inject(TYPES.LoggerPort) private readonly logger: LoggerPort,
     @inject(TYPES.ValidationPort) private readonly validation: ValidationPort
   ) {
@@ -260,6 +262,11 @@ export class WorkflowEngineService {
     const specContent = await this.templateService.generateSpecJson(updatedProject);
     await this.templateService.writeProjectFile(updatedProject, 'spec.json', specContent);
 
+    let handoffResult: HandoffResult | undefined;
+    if (approval.approved) {
+      handoffResult = await this.contextCompactionService.generatePhaseHandoff(updatedProject, phase);
+    }
+
     // Check if project can progress to next phase
     const nextPhase = this.stateMachine.getNextPhase(updatedProject.phase);
     let canProgressToNext = false;
@@ -272,6 +279,9 @@ export class WorkflowEngineService {
     const message = approval.approved 
       ? `${phase} phase approved and ready for progression`
       : `${phase} phase approval status updated`;
+    const messageWithHandoff = handoffResult
+      ? `${message}. Compact handoff: ${handoffResult.path} (${handoffResult.estimate.reductionPercentage}% estimated context reduction, ~${handoffResult.estimate.sourceTokens} -> ~${handoffResult.estimate.compactTokens} tokens)`
+      : message;
 
     this.logger.info('Approval status updated successfully', {
       correlationId,
@@ -283,7 +293,7 @@ export class WorkflowEngineService {
     return {
       success: true,
       updatedProject,
-      message,
+      message: messageWithHandoff,
       canProgressToNext
     };
   }
@@ -448,6 +458,9 @@ export class WorkflowEngineService {
       case WorkflowPhase.TASKS:
         if (!project.metadata.approvals.tasks.approved) {
           steps.push('Review and approve task breakdown');
+          if (project.metadata.checkpoints?.testCases.required && !project.metadata.checkpoints.testCases.reviewed) {
+            steps.push('Review TDD test cases and run sdd-review-test-cases');
+          }
           steps.push('Begin implementation after tasks approval');
         } else {
           steps.push('Begin implementation following the task breakdown');

--- a/src/application/services/WorkflowService.ts
+++ b/src/application/services/WorkflowService.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { TYPES } from '../../infrastructure/di/types.js';
 import { Project, WorkflowPhase } from '../../domain/types.js';
 import { ProjectRepository, LoggerPort } from '../../domain/ports.js';
+import { WorkflowDomainService } from '../../domain/services/DomainService.js';
 
 export interface WorkflowValidationResult {
   canProgress: boolean;
@@ -91,6 +92,13 @@ export class WorkflowService {
             canProgress: false,
             reason: 'Tasks must be generated and approved before implementation phase',
             requiredApprovals: ['tasks']
+          };
+        }
+        if (!WorkflowDomainService.isTestCaseReviewSatisfied(project)) {
+          return {
+            canProgress: false,
+            reason: 'TDD test cases must be reviewed before implementation because the test-case review checkpoint is enabled',
+            requiredApprovals: ['test-cases']
           };
         }
         return { canProgress: true };

--- a/src/application/services/staticSteering.ts
+++ b/src/application/services/staticSteering.ts
@@ -537,7 +537,7 @@ Note: Optional for new features or small additions. You can proceed directly to 
 1. \`sdd-init\` - Initialize spec with detailed project description
 2. \`sdd-requirements\` - Generate requirements document
 3. \`sdd-design\` - Interactive: "Have you reviewed requirements.md? [y/N]"
-4. \`sdd-tasks\` - Interactive: Confirms both requirements and design review
+4. \`sdd-tasks\` - Interactive: Confirms both requirements and design review, and asks whether TDD test cases need a review checkpoint
 
 ### Phase 2: Progress Tracking
 \`sdd-status\` - Check current progress and phases
@@ -557,14 +557,15 @@ Note: Optional for new features or small additions. You can proceed directly to 
 Managed by \`sdd-steering\` tool. Updates here reflect tool changes.
 
 ### Active Steering Files
-- \`product.md\`: Always included - Product context and business objectives
-- \`tech.md\`: Always included - Technology stack and architectural decisions
-- \`structure.md\`: Always included - File organization and code patterns
-- \`linus-review.md\`: Always included - Ensuring code quality of the projects
-- \`commit.md\`: Always included - Ensuring the commit / merge request / pull request title and message context
-- \`security-check.md\`: Always included - OWASP Top 10 security checklist (REQUIRED for code generation and review)
-- \`tdd-guideline.md\`: Always included - Test-Driven Development workflow (REQUIRED for all new features)
-- \`principles.md\`: Always included - Core coding principles (SOLID, DRY, KISS, YAGNI, Separation of Concerns, Modularity)
+Load steering documents on demand to control token usage:
+- \`product.md\`: Product context and business objectives
+- \`tech.md\`: Technology stack and architectural decisions
+- \`structure.md\`: File organization and code patterns
+- \`linus-review.md\`: Code quality review standards
+- \`commit.md\`: Commit and PR conventions
+- \`security-check.md\`: OWASP Top 10 checklist for code generation and review
+- \`tdd-guideline.md\`: TDD workflow for new features
+- \`principles.md\`: SOLID, DRY, KISS, YAGNI, Separation of Concerns, Modularity
 
 ### Custom Steering Files
 <!-- Added by sdd-steering-custom tool -->

--- a/src/cli/install-skills.ts
+++ b/src/cli/install-skills.ts
@@ -15,6 +15,7 @@ import { getDistCliDir, findTemplate } from './utils/find-package-root.js';
  * Component types that can be installed
  */
 export type ComponentType = 'skills' | 'steering' | 'rules' | 'contexts' | 'agents' | 'hooks';
+export type InstallProfile = 'lean' | 'full';
 
 /**
  * CLI options for install-skills command
@@ -56,6 +57,8 @@ export interface CLIOptions {
   antigravity: boolean;
   /** Enable all tool integrations (codex + antigravity) */
   allTools: boolean;
+  /** Installation profile for default unified install */
+  installProfile: InstallProfile;
 }
 
 /**
@@ -155,6 +158,7 @@ export class InstallSkillsCLI {
       codex: false,
       antigravity: false,
       allTools: false,
+      installProfile: 'lean',
     };
 
     for (let i = 0; i < args.length; i++) {
@@ -223,8 +227,17 @@ export class InstallSkillsCLI {
           options.hooksOnly = true;
           options.components.push('hooks');
           break;
+        case '--profile':
+          if (i + 1 < args.length) {
+            const profile = args[++i];
+            if (profile === 'lean' || profile === 'full') {
+              options.installProfile = profile;
+            }
+          }
+          break;
         case '--all':
           // Install all component types
+          options.installProfile = 'full';
           options.components = ['skills', 'steering', 'rules', 'contexts', 'agents', 'hooks'];
           break;
         case '--codex':
@@ -279,9 +292,9 @@ export class InstallSkillsCLI {
     const hasSpecificComponents = options.components.length > 0;
     const componentsToInstall = hasSpecificComponents
       ? options.components
-      : ['skills', 'steering', 'rules', 'contexts', 'agents', 'hooks'] as ComponentType[];
+      : this.getDefaultComponents(options.installProfile);
 
-    console.log('\n🚀 SDD Component Installer\n');
+    console.log(`\n🚀 SDD Component Installer (${options.installProfile} profile)\n`);
 
     for (const component of componentsToInstall) {
       switch (component) {
@@ -345,6 +358,14 @@ export class InstallSkillsCLI {
     }
 
     console.log('\n✨ Installation complete!\n');
+  }
+
+  private getDefaultComponents(profile: InstallProfile): ComponentType[] {
+    if (profile === 'full') {
+      return ['skills', 'steering', 'rules', 'contexts', 'agents', 'hooks'];
+    }
+
+    return ['skills', 'steering', 'hooks'];
   }
 
   /**
@@ -679,7 +700,8 @@ SDD Unified Installer
 
 Usage: npx sdd-mcp-server install [options]
 
-Installs SDD components (skills, steering, rules, contexts, agents, hooks) to your project.
+Installs SDD components to your project. The default lean profile installs skills,
+steering, and hooks only to reduce always-on context and token usage.
 
 Component Options (install specific types):
   --skills              Install skills only (to .claude/skills)
@@ -688,7 +710,9 @@ Component Options (install specific types):
   --contexts            Install contexts only (to .claude/contexts)
   --agents              Install agents only (to .claude/agents)
   --hooks               Install hooks only (to .claude/hooks)
-  --all                 Install all component types (default behavior)
+  --all                 Install all component types
+  --profile <profile>   Install profile when no component flags are provided:
+                        lean (default) or full
 
 Path Options (customize installation targets):
   --path <dir>          Target for skills (default: .claude/skills)
@@ -708,7 +732,8 @@ Other Options:
   --help, -h            Show this help message
 
 Examples:
-  npx sdd-mcp-server install                     # Install all components
+  npx sdd-mcp-server install                     # Lean install for lower token usage
+  npx sdd-mcp-server install --profile full      # Install all components
   npx sdd-mcp-server install --skills --rules    # Install skills and rules only
   npx sdd-mcp-server install --list              # List available components
   npx sdd-mcp-server install --codex             # Claude + Codex CLI support

--- a/src/domain/services/DomainService.ts
+++ b/src/domain/services/DomainService.ts
@@ -3,6 +3,11 @@
 import { Project, WorkflowPhase, Task } from '../types.js';
 
 export class WorkflowDomainService {
+  static isTestCaseReviewSatisfied(project: Project): boolean {
+    const testCaseCheckpoint = project.metadata.checkpoints?.testCases;
+    return !testCaseCheckpoint?.required || testCaseCheckpoint.reviewed;
+  }
+
   static canTransitionToPhase(project: Project, targetPhase: WorkflowPhase): boolean {
     const { phase, metadata } = project;
     const { approvals } = metadata;
@@ -21,7 +26,9 @@ export class WorkflowDomainService {
         return approvals.design.generated && approvals.design.approved;
 
       case WorkflowPhase.IMPLEMENTATION:
-        return approvals.tasks.generated && approvals.tasks.approved;
+        return approvals.tasks.generated &&
+               approvals.tasks.approved &&
+               this.isTestCaseReviewSatisfied(project);
 
       default:
         return false;
@@ -32,7 +39,8 @@ export class WorkflowDomainService {
     const { approvals } = project.metadata;
     return approvals.requirements.approved &&
            approvals.design.approved &&
-           approvals.tasks.approved;
+           approvals.tasks.approved &&
+           this.isTestCaseReviewSatisfied(project);
   }
 
   static getRequiredApprovals(project: Project, targetPhase: WorkflowPhase): string[] {
@@ -53,6 +61,9 @@ export class WorkflowDomainService {
     if (targetPhase === WorkflowPhase.IMPLEMENTATION) {
       if (!project.metadata.approvals.tasks.approved) {
         missing.push('tasks');
+      }
+      if (!this.isTestCaseReviewSatisfied(project)) {
+        missing.push('test-cases');
       }
     }
 

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -13,6 +13,8 @@ export interface ProjectMetadata {
   readonly updatedAt: Date;
   readonly language: string;
   readonly approvals: PhaseApprovals;
+  readonly workflowOptions?: WorkflowOptions;
+  readonly checkpoints?: WorkflowCheckpoints;
 }
 
 export interface PhaseApprovals {
@@ -24,6 +26,20 @@ export interface PhaseApprovals {
 export interface ApprovalStatus {
   readonly generated: boolean;
   readonly approved: boolean;
+}
+
+export interface WorkflowOptions {
+  readonly reviewTestCases: boolean;
+}
+
+export interface WorkflowCheckpoints {
+  readonly testCases: ReviewCheckpoint;
+}
+
+export interface ReviewCheckpoint {
+  readonly required: boolean;
+  readonly reviewed: boolean;
+  readonly reviewedAt?: Date;
 }
 
 export enum WorkflowPhase {

--- a/src/domain/workflow/WorkflowStateMachine.ts
+++ b/src/domain/workflow/WorkflowStateMachine.ts
@@ -1,6 +1,7 @@
 // Domain model for SDD workflow state transitions
 
 import { WorkflowPhase, Project, PhaseApprovals } from '../types.js';
+import { WorkflowDomainService } from '../services/DomainService.js';
 
 export interface StateTransition {
   from: WorkflowPhase;
@@ -86,8 +87,9 @@ export class WorkflowStateMachine {
         condition: {
           check: (project: Project) => 
             project.metadata.approvals.tasks.generated &&
-            project.metadata.approvals.tasks.approved,
-          errorMessage: 'Tasks must be generated and approved before implementation phase',
+            project.metadata.approvals.tasks.approved &&
+            WorkflowDomainService.isTestCaseReviewSatisfied(project),
+          errorMessage: 'Tasks must be generated and approved before implementation phase; test cases must be reviewed when that checkpoint is enabled',
           requiredApprovals: ['tasks']
         }
       },
@@ -376,6 +378,9 @@ export class WorkflowStateMachine {
     }
     if (approvals.tasks.generated && !approvals.tasks.approved) {
       recommendations.push('Tasks are ready for review and approval');
+    }
+    if (!WorkflowDomainService.isTestCaseReviewSatisfied(project)) {
+      recommendations.push('Review and approve TDD test cases before implementation');
     }
 
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,8 @@ if (isMCPMode) {
 }
 
 import "reflect-metadata";
+import { existsSync } from "fs";
+import nodePath from "path";
 import { createContainer } from "./infrastructure/di/container.js";
 import { TYPES } from "./infrastructure/di/types.js";
 import type { LoggerPort } from "./domain/ports";
@@ -133,6 +135,11 @@ async function createSimpleMCPServer() {
                 description: "Answers to clarification questions (second pass)",
                 additionalProperties: { type: "string" },
               },
+              reviewTestCases: {
+                type: "boolean",
+                description:
+                  "Enable an optional TDD test-case review checkpoint before implementation",
+              },
             },
             required: ["projectName"],
           },
@@ -170,6 +177,20 @@ async function createSimpleMCPServer() {
           },
         },
         {
+          name: "sdd-review-test-cases",
+          description: "Mark optional TDD test-case review checkpoint as reviewed",
+          inputSchema: {
+            type: "object",
+            properties: {
+              featureName: {
+                type: "string",
+                description: "Feature name from spec initialization",
+              },
+            },
+            required: ["featureName"],
+          },
+        },
+        {
           name: "sdd-quality-check",
           description: "Code quality analysis",
           inputSchema: {
@@ -196,6 +217,12 @@ async function createSimpleMCPServer() {
               featureName: {
                 type: "string",
                 description: "Feature name to load context for",
+              },
+              mode: {
+                type: "string",
+                enum: ["compact", "standard", "full"],
+                description:
+                  "Context size mode. Defaults to compact handoff context.",
               },
             },
             required: ["featureName"],
@@ -271,15 +298,10 @@ async function createSimpleMCPServer() {
         return await handleQualityCheckSimplified(args);
       case "sdd-approve":
         return await handleApproveSimplified(args);
+      case "sdd-review-test-cases":
+        return await handleReviewTestCasesSimplified(args);
       case "sdd-context-load":
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Project context loaded for ${args.featureName}. (Simplified MCP mode)`,
-            },
-          ],
-        };
+        return await handleContextLoadSimplified(args);
       case "sdd-validate-design":
         return {
           content: [
@@ -489,6 +511,9 @@ async function handleStatusSimplified(args: any) {
     status += `- Requirements: ${spec.approvals.requirements.generated ? "✅ Generated" : "❌ Not Generated"}${spec.approvals.requirements.approved ? ", ✅ Approved" : ", ❌ Not Approved"}\n`;
     status += `- Design: ${spec.approvals.design.generated ? "✅ Generated" : "❌ Not Generated"}${spec.approvals.design.approved ? ", ✅ Approved" : ", ❌ Not Approved"}\n`;
     status += `- Tasks: ${spec.approvals.tasks.generated ? "✅ Generated" : "❌ Not Generated"}${spec.approvals.tasks.approved ? ", ✅ Approved" : ", ❌ Not Approved"}\n\n`;
+    if (spec.checkpoints?.test_cases?.required) {
+      status += `**TDD Test Case Review**: ${spec.checkpoints.test_cases.reviewed ? "✅ Reviewed" : "❌ Pending"}\n`;
+    }
     status += `**Ready for Implementation**: ${spec.ready_for_implementation ? "✅ Yes" : "❌ No"}\n\n`;
     if (!spec.approvals.requirements.generated)
       status += `**Next Step**: Run \`sdd-requirements ${featureName}\``;
@@ -496,6 +521,8 @@ async function handleStatusSimplified(args: any) {
       status += `**Next Step**: Run \`sdd-design ${featureName}\``;
     else if (!spec.approvals.tasks.generated)
       status += `**Next Step**: Run \`sdd-tasks ${featureName}\``;
+    else if (spec.checkpoints?.test_cases?.required && !spec.checkpoints.test_cases.reviewed)
+      status += `**Next Step**: Review test cases, then run \`sdd-review-test-cases ${featureName}\``;
     else
       status += `**Next Step**: Run \`sdd-implement ${featureName}\` to begin implementation`;
     return { content: [{ type: "text", text: status }] };
@@ -527,6 +554,9 @@ async function handleStatusSimplified(args: any) {
       status += `- Requirements: ${spec.approvals.requirements.generated ? "✅" : "❌"}\n`;
       status += `- Design: ${spec.approvals.design.generated ? "✅" : "❌"}\n`;
       status += `- Tasks: ${spec.approvals.tasks.generated ? "✅" : "❌"}\n`;
+      if (spec.checkpoints?.test_cases?.required) {
+        status += `- Test cases reviewed: ${spec.checkpoints.test_cases.reviewed ? "✅" : "❌"}\n`;
+      }
       status += `- Ready: ${spec.ready_for_implementation ? "✅" : "❌"}\n\n`;
     }
   }
@@ -560,14 +590,45 @@ async function handleApproveSimplified(args: any) {
         ],
       };
     }
+    if (
+      phase === "tasks" &&
+      spec.checkpoints?.test_cases?.required &&
+      !spec.checkpoints.test_cases.reviewed
+    ) {
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Error: TDD test cases must be reviewed before approving tasks. ` +
+              `After review, run sdd-review-test-cases ${featureName}.`,
+          },
+        ],
+        isError: true,
+      };
+    }
     spec.approvals[phase].approved = true;
     spec.updated_at = new Date().toISOString();
+    spec.ready_for_implementation =
+      spec.approvals.requirements?.approved === true &&
+      spec.approvals.design?.approved === true &&
+      spec.approvals.tasks?.approved === true &&
+      (spec.checkpoints?.test_cases?.required !== true ||
+        spec.checkpoints.test_cases.reviewed === true);
     fs.writeFileSync(specPath, JSON.stringify(spec, null, 2));
+    const handoff = await generateCompactHandoffSimplified(featureName, phase);
     return {
       content: [
         {
           type: "text",
-          text: `## Phase Approved\n\n**Feature**: ${featureName}\n**Phase**: ${phase}\n**Status**: ✅ Approved`,
+          text:
+            `## Phase Approved\n\n` +
+            `**Feature**: ${featureName}\n` +
+            `**Phase**: ${phase}\n` +
+            `**Status**: ✅ Approved\n` +
+            `**Context Handoff**: ${handoff.relativePath}\n` +
+            `**Estimated Context Reduction**: ${handoff.reductionPercentage}% ` +
+            `(~${handoff.sourceTokens} → ~${handoff.compactTokens} tokens)`,
         },
       ],
     };
@@ -577,6 +638,292 @@ async function handleApproveSimplified(args: any) {
         {
           type: "text",
           text: `Error approving phase: ${(error as Error).message}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+async function handleContextLoadSimplified(args: any) {
+  const fs = await import("fs");
+  const path = await import("path");
+  const { featureName, mode = "compact" } = args || {};
+
+  if (!featureName) {
+    return {
+      content: [{ type: "text", text: "featureName is required" }],
+      isError: true,
+    };
+  }
+  if (!["compact", "standard", "full"].includes(mode)) {
+    return {
+      content: [{ type: "text", text: "mode must be compact, standard, or full" }],
+      isError: true,
+    };
+  }
+
+  try {
+    const { specDir, specPath } = ensureSimplifiedFeatureExists(featureName);
+    const handoffPath = path.join(specDir, "context", "handoff.md");
+
+    if (mode === "full") {
+      const context = await loadFullContextSimplified(featureName);
+      return { content: [{ type: "text", text: context }] };
+    }
+
+    if (!fs.existsSync(handoffPath)) {
+      await generateCompactHandoffSimplified(featureName, "requirements");
+    }
+
+    let context = fs.readFileSync(handoffPath, "utf8");
+    if (mode === "standard") {
+      context += `\n\n## Current Spec Metadata\n\n\`\`\`json\n${fs.readFileSync(specPath, "utf8")}\n\`\`\``;
+    }
+
+    return { content: [{ type: "text", text: context }] };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Error loading context: ${(error as Error).message}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+}
+
+function getSimplifiedSpecDir(featureName: string): string {
+  const sddDir = existsSync(nodePath.join(process.cwd(), ".spec")) ? ".spec" : ".kiro";
+  return nodePath.join(process.cwd(), sddDir, "specs", featureName);
+}
+
+function ensureSimplifiedFeatureExists(featureName: string): { specDir: string; specPath: string } {
+  const specDir = getSimplifiedSpecDir(featureName);
+  const specPath = nodePath.join(specDir, "spec.json");
+
+  if (!existsSync(specPath)) {
+    throw new Error(
+      `Feature "${featureName}" not found. Run sdd-init first or check the feature name.`
+    );
+  }
+
+  return { specDir, specPath };
+}
+
+async function generateCompactHandoffSimplified(featureName: string, approvedPhase: string) {
+  const fs = await import("fs");
+  const path = await import("path");
+  const { specDir } = ensureSimplifiedFeatureExists(featureName);
+  const contextDir = path.join(specDir, "context");
+
+  const documents = ["requirements.md", "design.md", "tasks.md", "spec.json"]
+    .map((name) => {
+      const filePath = path.join(specDir, name);
+      return fs.existsSync(filePath)
+        ? { name, filePath, content: fs.readFileSync(filePath, "utf8") }
+        : null;
+    })
+    .filter(Boolean) as Array<{ name: string; filePath: string; content: string }>;
+
+  if (documents.length === 0) {
+    throw new Error(
+      `Feature "${featureName}" has no source documents to compact.`
+    );
+  }
+
+  fs.mkdirSync(contextDir, { recursive: true });
+
+  const sourceCharacters = documents.reduce((sum, doc) => sum + doc.content.length, 0);
+  const spec = documents.find((doc) => doc.name === "spec.json");
+  const parsedSpec = spec ? JSON.parse(spec.content) : {};
+  const summaries = documents.map((doc) => summarizeDocumentSimplified(doc.name, doc.content));
+  const nextActions = getSimplifiedNextActions(approvedPhase, parsedSpec);
+  const draft = [
+    `# SDD Context Handoff: ${featureName}`,
+    "",
+    `Generated: ${new Date().toISOString()}`,
+    `Approved phase: ${approvedPhase}`,
+    "",
+    "## Workflow State",
+    "",
+    `- Requirements: ${formatSimplifiedApproval(parsedSpec.approvals?.requirements)}`,
+    `- Design: ${formatSimplifiedApproval(parsedSpec.approvals?.design)}`,
+    `- Tasks: ${formatSimplifiedApproval(parsedSpec.approvals?.tasks)}`,
+    parsedSpec.checkpoints?.test_cases?.required
+      ? `- TDD test-case review: ${parsedSpec.checkpoints.test_cases.reviewed ? "reviewed" : "pending"}`
+      : "- TDD test-case review: not required",
+    "",
+    "## Compact Phase Summaries",
+    "",
+    summaries.join("\n\n"),
+    "",
+    "## Next Actions",
+    "",
+    ...nextActions.map((action) => `- ${action}`),
+    "",
+    "## Source References",
+    "",
+    ...documents.map((doc) => `- ${doc.filePath}`),
+    "",
+    "## Context Budget Estimate",
+    "",
+    `- Full source context: ~${estimateTokensSimplified(sourceCharacters)} tokens`,
+    "- Handoff context: ~0 tokens",
+    "- Use `sdd-context-load` default compact mode for routine continuation.",
+    '- Use `sdd-context-load` with `mode: "full"` only for audits or ambiguous decisions.'
+  ].join("\n");
+
+  const compactTokens = estimateTokensSimplified(draft.length);
+  const sourceTokens = estimateTokensSimplified(sourceCharacters);
+  const reductionPercentage = sourceTokens === 0
+    ? 0
+    : Math.max(0, Math.round((1 - compactTokens / sourceTokens) * 100));
+  const content = draft.replace("- Handoff context: ~0 tokens", `- Handoff context: ~${compactTokens} tokens`);
+  const handoffPath = path.join(contextDir, "handoff.md");
+  fs.writeFileSync(handoffPath, content);
+  fs.writeFileSync(path.join(contextDir, `${approvedPhase}-handoff.md`), content);
+
+  return {
+    relativePath: path.relative(process.cwd(), handoffPath),
+    sourceTokens,
+    compactTokens,
+    reductionPercentage,
+  };
+}
+
+async function loadFullContextSimplified(featureName: string): Promise<string> {
+  const fs = await import("fs");
+  const path = await import("path");
+  const { specDir } = ensureSimplifiedFeatureExists(featureName);
+  const parts = [`# Full SDD Context: ${featureName}`];
+
+  for (const name of ["requirements.md", "design.md", "tasks.md", "spec.json"]) {
+    const filePath = path.join(specDir, name);
+    if (fs.existsSync(filePath)) {
+      parts.push(`## ${name}\n\n${fs.readFileSync(filePath, "utf8")}`);
+    }
+  }
+
+  return parts.join("\n\n");
+}
+
+function summarizeDocumentSimplified(name: string, content: string): string {
+  const lines = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("```"));
+  const headings = lines
+    .filter((line) => /^#{1,4}\s+/.test(line))
+    .map((line) => line.replace(/^#{1,4}\s+/, "").trim())
+    .filter(uniqueSimplifiedLine)
+    .slice(0, 8);
+  const bullets = lines
+    .filter((line) => /^[-*]\s+/.test(line) || /^\d+\.\s+/.test(line))
+    .map((line) => line.replace(/^[-*]\s+/, "").replace(/^\d+\.\s+/, "").trim())
+    .filter((line) => line.length <= 220)
+    .filter(uniqueSimplifiedLine)
+    .slice(0, 8);
+  const requirementLines = lines
+    .filter((line) => /\b(SHALL|MUST|WHEN|IF|THEN|WHERE|constraint|risk|security|performance|error|edge case)\b/i.test(line))
+    .map((line) => line.replace(/^[-*]\s+/, "").replace(/^\d+\.\s+/, "").trim())
+    .filter((line) => line.length <= 240)
+    .filter(uniqueSimplifiedLine)
+    .slice(0, 8);
+
+  return [
+    `### ${name}`,
+    headings.length > 0 ? "\n**Key sections:**" : "",
+    ...headings.map((line) => `- ${line}`),
+    bullets.length > 0 ? "\n**Important points:**" : "",
+    ...bullets.map((line) => `- ${line}`),
+    requirementLines.length > 0 ? "\n**Constraints and acceptance signals:**" : "",
+    ...requirementLines.map((line) => `- ${line}`),
+    headings.length === 0 && bullets.length === 0 && requirementLines.length === 0
+      ? "- No structured summary points found; open source document if this phase is active."
+      : "",
+  ].filter(Boolean).join("\n");
+}
+
+function uniqueSimplifiedLine(line: string, index: number, lines: string[]): boolean {
+  return lines.findIndex((candidate) => candidate.toLowerCase() === line.toLowerCase()) === index;
+}
+
+function getSimplifiedNextActions(approvedPhase: string, spec: any): string[] {
+  if (approvedPhase === "requirements") {
+    return ["Generate or review design using the approved requirements handoff."];
+  }
+  if (approvedPhase === "design") {
+    return ["Generate TDD task breakdown from the approved design handoff."];
+  }
+  if (spec.checkpoints?.test_cases?.required && !spec.checkpoints.test_cases.reviewed) {
+    return ["Review TDD test cases, then run sdd-review-test-cases before approving tasks."];
+  }
+  return ["Begin implementation with compact context loaded; open full docs only for ambiguous details."];
+}
+
+function formatSimplifiedApproval(status: any): string {
+  if (status?.generated && status?.approved) return "generated, approved";
+  if (status?.generated) return "generated, pending approval";
+  return "not generated";
+}
+
+function estimateTokensSimplified(characters: number): number {
+  return Math.max(1, Math.ceil(characters / 4));
+}
+
+async function handleReviewTestCasesSimplified(args: any) {
+  const fs = await import("fs");
+  const path = await import("path");
+  const { featureName } = args || {};
+  if (!featureName) {
+    return {
+      content: [{ type: "text", text: "featureName is required" }],
+      isError: true,
+    };
+  }
+
+  try {
+    const sddDir = fs.existsSync(path.join(process.cwd(), ".spec")) ? ".spec" : ".kiro";
+    const specPath = path.join(process.cwd(), sddDir, "specs", featureName, "spec.json");
+    const spec = JSON.parse(fs.readFileSync(specPath, "utf8"));
+
+    spec.workflow_options = {
+      ...(spec.workflow_options ?? {}),
+      review_test_cases: true,
+    };
+    spec.checkpoints = {
+      ...(spec.checkpoints ?? {}),
+      test_cases: {
+        required: true,
+        reviewed: true,
+        reviewed_at: new Date().toISOString(),
+      },
+    };
+    spec.updated_at = new Date().toISOString();
+    spec.ready_for_implementation =
+      spec.approvals?.requirements?.approved === true &&
+      spec.approvals?.design?.approved === true &&
+      spec.approvals?.tasks?.approved === true;
+
+    fs.writeFileSync(specPath, JSON.stringify(spec, null, 2));
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: `## TDD Test Cases Reviewed\n\n**Feature**: ${featureName}\n**Status**: ✅ Reviewed`,
+        },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: `Error reviewing test cases: ${(error as Error).message}`,
         },
       ],
       isError: true,
@@ -695,7 +1042,7 @@ async function handleInitSimplified(args: any) {
   const path = await import("path");
 
   try {
-    const { projectName, description } = args;
+    const { projectName, description, reviewTestCases = false } = args;
 
     if (!description || typeof description !== "string") {
       throw new Error("Description is required for project initialization");
@@ -734,6 +1081,15 @@ async function handleInitSimplified(args: any) {
         tasks: {
           generated: false,
           approved: false,
+        },
+      },
+      workflow_options: {
+        review_test_cases: reviewTestCases === true,
+      },
+      checkpoints: {
+        test_cases: {
+          required: reviewTestCases === true,
+          reviewed: reviewTestCases !== true,
         },
       },
       ready_for_implementation: false,
@@ -814,7 +1170,7 @@ Note: Optional for new features or small additions. You can proceed directly to 
 1. \`sdd-init\` - Initialize spec with detailed project description
 2. \`sdd-requirements\` - Generate requirements document
 3. \`sdd-design\` - Interactive: "Have you reviewed requirements.md? [y/N]"
-4. \`sdd-tasks\` - Interactive: Confirms both requirements and design review
+4. \`sdd-tasks\` - Interactive: Confirms requirements/design review and asks whether TDD test cases need a review checkpoint
 
 ### Phase 2: Progress Tracking
 \`sdd-status\` - Check current progress and phases
@@ -834,14 +1190,15 @@ Note: Optional for new features or small additions. You can proceed directly to 
 Managed by \`sdd-steering\` tool. Updates here reflect tool changes.
 
 ### Active Steering Files
-- \`product.md\`: Always included - Product context and business objectives
-- \`tech.md\`: Always included - Technology stack and architectural decisions
-- \`structure.md\`: Always included - File organization and code patterns
-- \`linus-review.md\`: Always included - Ensuring code quality of the projects
-- \`commit.md\`: Always included - Ensuring the commit / merge request / pull request title and message context
-- \`security-check.md\`: Always included - OWASP Top 10 security checklist (REQUIRED for code generation and review)
-- \`tdd-guideline.md\`: Always included - Test-Driven Development workflow (REQUIRED for all new features)
-- \`principles.md\`: Always included - Core coding principles (SOLID, DRY, KISS, YAGNI, Separation of Concerns, Modularity)
+Load steering documents on demand to control token usage:
+- \`product.md\`: Product context and business objectives
+- \`tech.md\`: Technology stack and architectural decisions
+- \`structure.md\`: File organization and code patterns
+- \`linus-review.md\`: Code quality review standards
+- \`commit.md\`: Commit and PR conventions
+- \`security-check.md\`: OWASP Top 10 checklist for code generation and review
+- \`tdd-guideline.md\`: TDD workflow for new features
+- \`principles.md\`: SOLID, DRY, KISS, YAGNI, Separation of Concerns, Modularity
 
 ### Custom Steering Files
 <!-- Added by sdd-steering-custom tool -->
@@ -869,6 +1226,7 @@ Managed by \`sdd-steering\` tool. Updates here reflect tool changes.
 
 **Feature Name**: \`${featureName}\`
 **Description**: ${description}
+**TDD Test Case Review Checkpoint**: ${reviewTestCases === true ? "Enabled" : "Disabled"}
 
 **Created Files**:
 - \`.spec/specs/${featureName}/spec.json\` - Project metadata and phase tracking
@@ -945,7 +1303,7 @@ async function main(): Promise<void> {
           templates: "Handlebars-based template generation with inheritance",
         },
         tools: {
-          count: 10,
+          count: 11,
           categories: [
             "sdd-init",
             "sdd-requirements",
@@ -954,6 +1312,7 @@ async function main(): Promise<void> {
             "sdd-implement",
             "sdd-status",
             "sdd-approve",
+            "sdd-review-test-cases",
             "sdd-quality-check",
             "sdd-context-load",
             "sdd-template-render",

--- a/src/infrastructure/di/container.ts
+++ b/src/infrastructure/di/container.ts
@@ -91,6 +91,7 @@ import { WorkflowValidationService } from "../../application/services/WorkflowVa
 import { CodebaseAnalysisService } from "../../application/services/CodebaseAnalysisService.js";
 import { SteeringDocumentService } from "../../application/services/SteeringDocumentService.js";
 import { ProjectContextService } from "../../application/services/ProjectContextService.js";
+import { ContextCompactionService } from "../../application/services/ContextCompactionService.js";
 import { RequirementsClarificationService } from "../../application/services/RequirementsClarificationService.js";
 import { SteeringContextLoader } from "../../application/services/SteeringContextLoader.js";
 import { DescriptionAnalyzer } from "../../application/services/DescriptionAnalyzer.js";
@@ -212,6 +213,9 @@ export function createContainer(): Container {
   container
     .bind<ProjectContextService>(TYPES.ProjectContextService)
     .to(ProjectContextService);
+  container
+    .bind<ContextCompactionService>(TYPES.ContextCompactionService)
+    .to(ContextCompactionService);
   container
     .bind<RequirementsClarificationService>(
       TYPES.RequirementsClarificationService,

--- a/src/infrastructure/di/types.ts
+++ b/src/infrastructure/di/types.ts
@@ -30,6 +30,7 @@ export const TYPES = {
   CodebaseAnalysisService: Symbol.for("CodebaseAnalysisService"),
   SteeringDocumentService: Symbol.for("SteeringDocumentService"),
   ProjectContextService: Symbol.for("ProjectContextService"),
+  ContextCompactionService: Symbol.for("ContextCompactionService"),
   RequirementsClarificationService: Symbol.for(
     "RequirementsClarificationService",
   ),

--- a/src/infrastructure/mcp/ResourceManager.ts
+++ b/src/infrastructure/mcp/ResourceManager.ts
@@ -158,6 +158,15 @@ export class ResourceManager {
           design: { generated: false, approved: false },
           tasks: { generated: false, approved: false }
         },
+        workflow_options: {
+          review_test_cases: false
+        },
+        checkpoints: {
+          test_cases: {
+            required: false,
+            reviewed: true
+          }
+        },
         ready_for_implementation: false
       }, null, 2),
       'sdd://templates/requirements.md': `# Requirements Document
@@ -222,7 +231,18 @@ export class ResourceManager {
           language: project.metadata.language,
           phase: project.phase,
           approvals: project.metadata.approvals,
-          ready_for_implementation: project.phase === 'implementation-ready'
+          workflow_options: {
+            review_test_cases: project.metadata.workflowOptions?.reviewTestCases ?? false
+          },
+          checkpoints: {
+            test_cases: {
+              required: project.metadata.checkpoints?.testCases.required ?? false,
+              reviewed: project.metadata.checkpoints?.testCases.reviewed ?? true
+            }
+          },
+          ready_for_implementation: project.phase === 'implementation-ready' &&
+            (project.metadata.checkpoints?.testCases.required !== true ||
+              project.metadata.checkpoints.testCases.reviewed)
         }, null, 2);
         break;
       

--- a/src/infrastructure/mcp/ToolRegistry.ts
+++ b/src/infrastructure/mcp/ToolRegistry.ts
@@ -249,7 +249,23 @@ export class ToolRegistry {
       ],
       'sdd-tasks': [
         {
-          description: 'Generate implementation tasks',
+          description: 'Generate implementation tasks without extra TDD test-case review',
+          arguments: {
+            projectId: 'proj_123456',
+            reviewTestCases: false
+          }
+        },
+        {
+          description: 'Generate implementation tasks and require TDD test-case review before implementation',
+          arguments: {
+            projectId: 'proj_123456',
+            reviewTestCases: true
+          }
+        }
+      ],
+      'sdd-review-test-cases': [
+        {
+          description: 'Mark optional TDD test-case review checkpoint as reviewed',
           arguments: {
             projectId: 'proj_123456'
           }
@@ -261,6 +277,22 @@ export class ToolRegistry {
           arguments: {
             code: 'function example() {\n  if (condition) {\n    return result;\n  }\n}',
             language: 'typescript'
+          }
+        }
+      ],
+      'sdd-context-load': [
+        {
+          description: 'Load compact handoff context for routine continuation',
+          arguments: {
+            projectId: 'proj_123456',
+            mode: 'compact'
+          }
+        },
+        {
+          description: 'Load full phase documents only when detailed audit context is required',
+          arguments: {
+            projectId: 'proj_123456',
+            mode: 'full'
           }
         }
       ]
@@ -277,7 +309,7 @@ export class ToolRegistry {
     const tools = Array.from(this.tools.keys());
     
     const toolsByCategory: Record<string, string[]> = {
-      'Project Management': ['sdd-init', 'sdd-status'],
+      'Project Management': ['sdd-init', 'sdd-status', 'sdd-context-load'],
       'Workflow': ['sdd-requirements', 'sdd-design', 'sdd-tasks'],
       'Quality Assurance': ['sdd-quality-check']
     };

--- a/src/infrastructure/schemas/project.schema.ts
+++ b/src/infrastructure/schemas/project.schema.ts
@@ -13,8 +13,18 @@ export const projectSchema = {
     metadata: {
       type: 'object',
       properties: {
-        createdAt: { type: 'string', format: 'date-time' },
-        updatedAt: { type: 'string', format: 'date-time' },
+        createdAt: {
+          anyOf: [
+            { type: 'string', format: 'date-time' },
+            { type: 'object' }
+          ]
+        },
+        updatedAt: {
+          anyOf: [
+            { type: 'string', format: 'date-time' },
+            { type: 'object' }
+          ]
+        },
         language: { type: 'string', enum: ['en', 'ja', 'zh-TW'] },
         approvals: {
           type: 'object',
@@ -45,6 +55,33 @@ export const projectSchema = {
             }
           },
           required: ['requirements', 'design', 'tasks']
+        },
+        workflowOptions: {
+          type: 'object',
+          properties: {
+            reviewTestCases: { type: 'boolean' }
+          },
+          required: ['reviewTestCases']
+        },
+        checkpoints: {
+          type: 'object',
+          properties: {
+            testCases: {
+              type: 'object',
+              properties: {
+                required: { type: 'boolean' },
+                reviewed: { type: 'boolean' },
+                reviewedAt: {
+                  anyOf: [
+                    { type: 'string', format: 'date-time' },
+                    { type: 'object' }
+                  ]
+                }
+              },
+              required: ['required', 'reviewed']
+            }
+          },
+          required: ['testCases']
         }
       },
       required: ['createdAt', 'updatedAt', 'language', 'approvals']


### PR DESCRIPTION
## Summary
- Promote v3.4.0 compact context handoffs onto current master.
- Preserve v3.3.0 multi-tool install support while adding lean install defaults, optional TDD test-case review checkpoint, and context loading modes.
- Update package, changelog, README, architecture, and steering docs for v3.4.0.

## Testing
- [x] npm run typecheck
- [x] npm run build
- [x] npx jest '--testPathPattern=__tests__.*\.test\.ts$' '--testPathIgnorePattern=integration|e2e'
- [x] npm_config_cache=/private/tmp/sdd-mcp-npm-cache npm pack --dry-run

## Release
- Tag after merge: v3.4.0
- npm publish target: sdd-mcp-server@3.4.0