### PR TITLE
feat(routing): use Sol medium for implementation

### DIFF
--- a/.spec/specs/optimizing-for-different-llm/design.md
+++ b/.spec/specs/optimizing-for-different-llm/design.md
@@ -10,7 +10,7 @@ The implementation preserves the existing CLI entry point and manager discovery 
 
 - Resolve `codex` or `claude-code` before the first filesystem write.
 - Generate only native artifacts for the selected primary target.
-- Route high-level roles to Sol or Opus and default implementation/TDD roles to Luna or Sonnet.
+- Route high-level roles to Sol or Opus and default implementation/TDD roles to Sol with medium effort or Sonnet.
 - Make phase skills request the specialist role so model metadata affects real work.
 - Update `.gitignore` safely and idempotently.
 - Preserve existing automation, custom paths, user-authored files, and unrelated integrations.
@@ -59,7 +59,7 @@ Claude Code keeps the current `.claude/` structure. Codex uses `.agents/skills/`
 
 ### AD-4: Centralize Role Routing
 
-One immutable role policy maps each supported role to a task class and provider-specific model settings. Renderers consume this policy. `gpt-5.6-luna` is the default Codex model for implementation and TDD roles, while `gpt-5.6-terra` remains supported without a default role.
+One immutable role policy maps each supported role to a task class and provider-specific model settings. Renderers consume this policy. `gpt-5.6-sol` is the default Codex model for implementation and TDD roles with medium effort, while `gpt-5.6-luna` and `gpt-5.6-terra` remain supported without a default role.
 
 ### AD-5: Preserve Existing Files by Default
 
@@ -221,7 +221,7 @@ export interface RoleModelRoute {
   taskClass: TaskClass;
   codex: {
     model: 'gpt-5.6-sol' | 'gpt-5.6-terra' | 'gpt-5.6-luna';
-    reasoningEffort: 'xhigh' | 'max';
+    reasoningEffort: 'xhigh' | 'medium';
   };
   claudeCode: {
     model: 'opus' | 'sonnet';
@@ -232,8 +232,8 @@ export interface RoleModelRoute {
 **Invariants:**
 
 - Planner, architect, reviewer, and security-auditor are `high-level`.
-- Implementer and TDD-guide are `implementation` and use the default Luna/max route.
-- The supported Codex model constants also contain `gpt-5.6-terra`, but no default role selects it.
+- Implementer and TDD-guide are `implementation` and use the default Sol/medium route.
+- The supported Codex model constants also contain `gpt-5.6-terra` and `gpt-5.6-luna`, but neither is selected by a default role.
 
 ### Installation Results
 
@@ -515,10 +515,10 @@ export function updateGeneratedIgnores(
 | architect | high-level | `gpt-5.6-sol` | xhigh | `opus` |
 | reviewer | high-level | `gpt-5.6-sol` | xhigh | `opus` |
 | security-auditor | high-level | `gpt-5.6-sol` | xhigh | `opus` |
-| implementer | implementation | `gpt-5.6-luna` | max | `sonnet` |
-| tdd-guide | implementation | `gpt-5.6-luna` | max | `sonnet` |
+| implementer | implementation | `gpt-5.6-sol` | medium | `sonnet` |
+| tdd-guide | implementation | `gpt-5.6-sol` | medium | `sonnet` |
 
-`gpt-5.6-luna` is the default Codex model for implementation and TDD roles. `gpt-5.6-terra` remains supported but is not selected by a default role.
+`gpt-5.6-sol` is the default Codex model for implementation and TDD roles. `gpt-5.6-luna` and `gpt-5.6-terra` remain supported but are not selected by a default role.
 
 ## Phase Skill Delegation
 
@@ -605,7 +605,7 @@ No catch block converts a failed target install into an unconditional success me
 - Codex rules and contexts remain reference files below `.codex/guidance/`.
 - Skills retain progressive disclosure and load their full instructions only when invoked.
 - Phase delegation passes compact handoffs by default.
-- Sol and Opus are limited to approved high-level roles; Luna and Sonnet handle implementation and TDD roles.
+- Sol with xhigh effort handles high-level roles, while Sol with medium effort and Sonnet handle implementation and TDD roles.
 - Terra remains supported but is not activated by default.
 
 ## Testing Strategy
@@ -627,7 +627,7 @@ No catch block converts a failed target install into an unconditional success me
 - One override at a time and combined overrides.
 - Rejection of Codex prompt guidance below `.codex/rules/`, including normalized `..` traversal forms.
 - Exact role-to-model and skill-to-role mappings.
-- Luna/max is the default implementation route; Terra has no default role.
+- Sol/medium is the default implementation route; Luna and Terra remain supported without a default role.
 
 **Rendering:**
 

--- a/.spec/specs/optimizing-for-different-llm/implementation.md
+++ b/.spec/specs/optimizing-for-different-llm/implementation.md
@@ -2,7 +2,7 @@
 
 ## Outcome
 
-Implementation completed on 2026-07-13. The unified installer now resolves one primary `codex` or `claude-code` target, writes native preserve-first artifacts, updates `.gitignore`, rejects every Codex destination below `.codex/rules`, rejects symlinked or out-of-root destinations, propagates optional integration and template failures, and applies the current role/model policy through native agent metadata and phase-skill delegation: Sol/xhigh for high-level Codex roles and Luna/max for implementation and TDD.
+Implementation completed on 2026-07-13. The unified installer now resolves one primary `codex` or `claude-code` target, writes native preserve-first artifacts, updates `.gitignore`, rejects every Codex destination below `.codex/rules`, rejects symlinked or out-of-root destinations, propagates optional integration and template failures, and applies the current role/model policy through native agent metadata and phase-skill delegation: Sol/xhigh for high-level Codex roles and Sol/medium for implementation and TDD.
 
 ## Verification
 

--- a/.spec/specs/optimizing-for-different-llm/requirements.md
+++ b/.spec/specs/optimizing-for-different-llm/requirements.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The SDD component installer currently installs a Claude Code-oriented full profile and adds Codex support as an optional secondary integration. This feature makes the target AI agent explicit so that a developer can install native files for either Codex or Claude Code without loading irrelevant guidance. It assigns high-capability models to planning, review, and security work while making `gpt-5.6-luna` with maximum reasoning the default for implementation and TDD work.
+The SDD component installer currently installs a Claude Code-oriented full profile and adds Codex support as an optional secondary integration. This feature makes the target AI agent explicit so that a developer can install native files for either Codex or Claude Code without loading irrelevant guidance. It assigns high-level models to planning, review, and security work while making `gpt-5.6-sol` with medium reasoning the default for implementation and TDD work.
 
 ## Primary User Goal
 
@@ -120,7 +120,7 @@ THE installer SHALL write only the artifacts required by that target and the tar
 
 ### FR-7: Codex Model Routing
 
-**Objective:** As a Codex user, I want demanding work assigned to Sol and default implementation work assigned to Luna so that model capability and reasoning effort follow task complexity.
+**Objective:** As a Codex user, I want demanding work assigned to Sol with xhigh reasoning and implementation work assigned to Sol with medium reasoning so that model capability and reasoning effort follow task complexity.
 
 **EARS Specification:**
 
@@ -131,8 +131,8 @@ THEN the installer SHALL assign Codex models and reasoning effort according to e
 
 1. Planner, architect, reviewer, and security-auditor agents use `gpt-5.6-sol`.
 2. Sol-backed agents use `model_reasoning_effort = "xhigh"` by default.
-3. Implementer and TDD-guide agents use `gpt-5.6-luna`.
-4. Luna-backed agents use `model_reasoning_effort = "max"` by default.
+3. Implementer and TDD-guide agents use `gpt-5.6-sol`.
+4. Implementation agents use `model_reasoning_effort = "medium"` by default.
 5. `gpt-5.6-terra` remains a supported model identifier but is assigned to no default SDD role.
 6. Model identifiers and role mappings are defined in one maintainable source of truth rather than repeated independently across generators.
 
@@ -310,7 +310,7 @@ The implementation SHALL provide automated verification for every target-depende
 
 1. In an interactive terminal, omitting `--target` from a full-profile install means the user wants to be prompted.
 2. In a non-interactive environment, preserving the prior Claude Code-oriented default is less disruptive than failing the command.
-3. `gpt-5.6-sol` is the default for high-level reasoning roles; `gpt-5.6-luna` is the default for implementation and TDD roles; `gpt-5.6-terra` remains supported without a default SDD role.
+3. `gpt-5.6-sol` is the default for high-level reasoning and implementation/TDD roles, with xhigh effort for high-level roles and medium effort for implementation roles; `gpt-5.6-terra` and `gpt-5.6-luna` remain supported without a default SDD role.
 4. Planner, architect, reviewer, and security-auditor are high-level roles.
 5. Implementer and TDD-guide are implementation roles.
 6. Generated local agent directories are ignored, while root guidance and project steering documents are intended to be reviewable and trackable.

--- a/.spec/specs/optimizing-for-different-llm/tasks.md
+++ b/.spec/specs/optimizing-for-different-llm/tasks.md
@@ -45,7 +45,7 @@ Scenario counts can increase when defects reveal missing boundaries, but the sui
 1. Claude Code policy exposes the existing `.claude/` paths and `.claude/` ignore entry.
 2. Codex policy exposes `.agents/skills/`, `.codex/agents/`, guidance, hooks, and root paths.
 3. Every supported role has the exact approved model and Codex effort.
-4. `gpt-5.6-luna` is the default implementation/TDD route with `max` effort; `gpt-5.6-terra` remains supported but has no default role.
+4. `gpt-5.6-sol` is the default implementation/TDD route with `medium` effort; `gpt-5.6-luna` and `gpt-5.6-terra` remain supported but have no default role.
 5. Every routed skill maps to the approved specialist.
 6. Explicit path overrides replace only their corresponding defaults.
 7. A Codex guidance path below `.codex/rules/` is rejected.
@@ -59,7 +59,7 @@ Scenario counts can increase when defects reveal missing boundaries, but the sui
 **Acceptance Criteria:**
 
 - [ ] All approved default paths and model routes are asserted exactly.
-- [ ] Luna/max is assigned to implementation and TDD roles; Terra has no default role.
+- [ ] Sol/medium is assigned to implementation and TDD roles; Luna and Terra have no default role.
 - [ ] Invalid target and semantic path collisions are type-safe or rejected.
 - [ ] The module has no filesystem or network dependency.
 
@@ -336,7 +336,7 @@ Scenario counts can increase when defects reveal missing boundaries, but the sui
 
 1. Every output contains `name`, `description`, and `developer_instructions`.
 2. High-level roles render `gpt-5.6-sol` and xhigh effort.
-3. Implementation roles render `gpt-5.6-luna` and max effort.
+3. Implementation roles render `gpt-5.6-sol` and medium effort.
 4. Quotes, backslashes, Unicode, and multiline instructions are escaped as TOML data.
 5. Terra never appears in a default agent file.
 6. Unknown roles fail without writing partial TOML.
@@ -631,7 +631,7 @@ Scenario counts can increase when defects reveal missing boundaries, but the sui
 **Test Scenarios:**
 
 1. Full output contains native skills, guidance, agent TOML, hooks, runner, steering, and `AGENTS.md`.
-2. Four agents use Sol/xhigh and two use Luna/max.
+2. Four agents use Sol/xhigh and two use Sol/medium.
 3. Terra is absent from default agent output.
 4. `.gitignore` contains `.agents/` and `.codex/` and no implicit Claude entry.
 5. No `.codex/rules/`, `.claude/`, or `CLAUDE.md` primary artifact exists.
@@ -740,7 +740,7 @@ Scenario counts can increase when defects reveal missing boundaries, but the sui
 1. Help lists `--target codex|claude-code` and target-aware path behavior.
 2. README contains explicit and interactive full-profile examples.
 3. Installation guide contains a target-to-output table.
-4. Model tables list Sol/Luna and Opus/Sonnet defaults, with Terra's supported-but-unassigned status.
+4. Model tables list Sol/xhigh and Sol/medium plus Opus/Sonnet defaults; Luna and Terra remain supported-but-unassigned.
 5. Preview access, compact handoffs, delegation token cost, and legacy `--codex` behavior are documented.
 
 **TDD Cycle:**
@@ -854,7 +854,7 @@ Tasks 1.1 and 2.1 can begin independently. Tasks 1.2–1.3, 2.2–2.4, and 3.1�
 - [ ] Unit, integration, and E2E coverage remains close to the 70/20/10 pyramid.
 - [ ] Both full-profile output trees contain native files and no implicit primary artifacts for the other target.
 - [ ] All six agent roles use the approved model mapping.
-- [ ] Luna/max is the default implementation route and Terra has no default role.
+- [ ] Sol/medium is the default implementation route; Luna and Terra have no default role.
 - [ ] Repeated installs preserve user files and make no redundant `.gitignore` edits.
 - [ ] Interactive, non-interactive, legacy, cancellation, and invalid-option journeys behave as specified.
 - [ ] Compact handoff delegation and fallback instructions are present in routed skills.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,9 +60,9 @@ Project-specific context documents. Edit these to describe your project:
 | Work class | Codex | Claude Code |
 |------------|-------|-------------|
 | Planning, architecture, review, security | `gpt-5.6-sol` with xhigh effort | `opus` |
-| Implementation and TDD (default) | `gpt-5.6-luna` with max effort | `sonnet` |
+| Implementation and TDD (default) | `gpt-5.6-sol` with medium effort | `sonnet` |
 
-Codex uses `gpt-5.6-luna` as the default model for routed work. High-level advisor roles override that default with `gpt-5.6-sol` at xhigh effort. `gpt-5.6-terra` remains a supported model but is not assigned to a default SDD role. Routed skills use compact specialist handoffs and continue in the current agent when delegation is unavailable.
+Codex uses `gpt-5.6-sol` as the default model for routed work. High-level advisor roles use xhigh effort, while implementation and TDD roles use medium effort. `gpt-5.6-luna` and `gpt-5.6-terra` remain supported models but are not assigned to a default SDD role. Routed skills use compact specialist handoffs and continue in the current agent when delegation is unavailable.
 For the complete role map, generated-file examples, and delegation flow, see [docs/MODEL-ROUTING.md](docs/MODEL-ROUTING.md).
 
 ## MCP Tools

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -271,9 +271,9 @@ npx sdd-mcp-server install --list
 | Roles | Task class | Codex | Claude Code |
 |-------|------------|-------|-------------|
 | planner, architect, reviewer, security-auditor | High-level advisor | `gpt-5.6-sol`, xhigh effort | `opus` |
-| implementer, tdd-guide | Implementation (default) | `gpt-5.6-luna`, max effort | `sonnet` |
+| implementer, tdd-guide | Implementation (default) | `gpt-5.6-sol`, medium effort | `sonnet` |
 
-Codex uses `gpt-5.6-luna` as the default model for routed work. High-level advisor roles override that default with `gpt-5.6-sol` at xhigh effort. `gpt-5.6-terra` remains supported but is not selected by a default role.
+Codex uses `gpt-5.6-sol` as the default model for routed work. High-level advisor roles use xhigh effort, while implementation and TDD roles use medium effort. `gpt-5.6-luna` and `gpt-5.6-terra` remain supported but are not selected by a default role.
 See [docs/MODEL-ROUTING.md](docs/MODEL-ROUTING.md) for the execution flow and native output details.
 
 Generated local installs under `.claude/`, `.agents/`, and `.codex/` are project outputs. Source assets live in the root component directories and are included in the npm package.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Codex implementation and TDD routing now uses `gpt-5.6-sol` with `medium` reasoning instead of the previous Luna/max route.
+
 ## [3.5.0] - 2026-07-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -217,9 +217,9 @@ The installer creates only the selected primary target's native artifacts, prese
 | Work | Codex | Claude Code |
 |------|-------|-------------|
 | Planning, architecture, review, security | `gpt-5.6-sol` (`xhigh`) | `opus` |
-| Implementation and TDD (default) | `gpt-5.6-luna` (`max`) | `sonnet` |
+| Implementation and TDD (default) | `gpt-5.6-sol` (`medium`) | `sonnet` |
 
-Codex uses `gpt-5.6-luna` as the default model for routed work. High-level advisor roles override that default with `gpt-5.6-sol` at xhigh effort. `gpt-5.6-terra` remains supported but is not selected by a default SDD role.
+Codex uses `gpt-5.6-sol` as the default model for routed work. High-level advisor roles use xhigh effort, while implementation and TDD roles use medium effort. `gpt-5.6-luna` and `gpt-5.6-terra` remain supported model identifiers but are not selected by a default SDD role.
 For a detailed explanation of role selection, native agent metadata, delegation, and rerun behavior, see [Model Routing](docs/MODEL-ROUTING.md).
 
 ### Component Architecture & Relationships

--- a/docs/INSTALL-GUIDE.md
+++ b/docs/INSTALL-GUIDE.md
@@ -72,10 +72,10 @@ Installed agents include model metadata selected by role:
 | Architect | High-level advisor | `gpt-5.6-sol`, xhigh effort | `opus` |
 | Reviewer | High-level advisor | `gpt-5.6-sol`, xhigh effort | `opus` |
 | Security auditor | High-level advisor | `gpt-5.6-sol`, xhigh effort | `opus` |
-| Implementer | Implementation (default) | `gpt-5.6-luna`, max effort | `sonnet` |
-| TDD guide | Implementation (default) | `gpt-5.6-luna`, max effort | `sonnet` |
+| Implementer | Implementation (default) | `gpt-5.6-sol`, medium effort | `sonnet` |
+| TDD guide | Implementation (default) | `gpt-5.6-sol`, medium effort | `sonnet` |
 
-Codex uses `gpt-5.6-luna` as the default model for routed work. High-level advisor roles override that default with `gpt-5.6-sol` at xhigh effort. `gpt-5.6-terra` remains supported but is not selected by a default SDD role. Phase skills use compact handoffs when asking the matching specialist to work, then wait for and integrate the result. When the host cannot delegate, the skill states the fallback and continues in the current agent.
+Codex uses `gpt-5.6-sol` as the default model for routed work. High-level advisor roles use xhigh effort, while implementation and TDD roles use medium effort. `gpt-5.6-luna` and `gpt-5.6-terra` remain supported but are not selected by a default SDD role. Phase skills use compact handoffs when asking the matching specialist to work, then wait for and integrate the result. When the host cannot delegate, the skill states the fallback and continues in the current agent.
 
 GPT-5.6 preview access depends on the user's eligible Codex workspace or API organization; generated files do not grant access or bypass host entitlement checks. Specialist delegation can consume more total tokens than a single-agent run because handoffs, specialist work, and result integration add work; compact handoffs reduce but do not eliminate that cost.
 See [Model Routing](MODEL-ROUTING.md) for the complete role map, generated Codex/Claude Code examples, delegation flow, and rerun behavior.

--- a/docs/MODEL-ROUTING.md
+++ b/docs/MODEL-ROUTING.md
@@ -5,10 +5,9 @@ This guide explains how SDD-MCP assigns models to specialized agents and what ha
 ## Short version
 
 For Codex installs:
-
-- `gpt-5.6-luna` with `max` reasoning is the default route for implementation and TDD work.
-- `gpt-5.6-sol` with `xhigh` reasoning is reserved for high-level advisor work: requirements planning, architecture, review, and security.
-- `gpt-5.6-terra` remains a supported model identifier, but no default SDD role selects it.
+- `gpt-5.6-sol` with `medium` reasoning is the default route for implementation and TDD work.
+- `gpt-5.6-sol` with `xhigh` reasoning remains reserved for high-level advisor work: requirements planning, architecture, review, and security.
+- `gpt-5.6-luna` and `gpt-5.6-terra` remain supported model identifiers, but no default SDD role selects them.
 
 For Claude Code installs, the equivalent aliases are `sonnet` for implementation/TDD and `opus` for high-level advisor work.
 
@@ -24,8 +23,8 @@ The installer assigns a model from the agent's role, not from the filename alone
 | `architect` | `/sdd-design` | `gpt-5.6-sol` / `xhigh` | `opus` |
 | `reviewer` | `/sdd-review` | `gpt-5.6-sol` / `xhigh` | `opus` |
 | `security-auditor` | `/sdd-security-check` | `gpt-5.6-sol` / `xhigh` | `opus` |
-| `implementer` | `/sdd-implement`, `/simple-task` | `gpt-5.6-luna` / `max` | `sonnet` |
-| `tdd-guide` | `/sdd-test-gen` | `gpt-5.6-luna` / `max` | `sonnet` |
+| `implementer` | `/sdd-implement`, `/simple-task` | `gpt-5.6-sol` / `medium` | `sonnet` |
+| `tdd-guide` | `/sdd-test-gen` | `gpt-5.6-sol` / `medium` | `sonnet` |
 
 `/sdd-commit` deliberately has no specialist route. Commit guidance stays with the current agent because it needs the current session's complete implementation and verification context.
 
@@ -47,8 +46,8 @@ model_reasoning_effort = "xhigh"
 ```toml
 # Default implementation agent
 name = "implementer"
-model = "gpt-5.6-luna"
-model_reasoning_effort = "max"
+model = "gpt-5.6-sol"
+model_reasoning_effort = "medium"
 ```
 
 The `model` field selects the model identifier. `model_reasoning_effort` controls the reasoning setting requested for that model. The installer does not call a model API or check entitlement; the Codex host applies the generated configuration and handles availability.

--- a/src/__tests__/unit/cli/documentation-consistency.test.ts
+++ b/src/__tests__/unit/cli/documentation-consistency.test.ts
@@ -13,9 +13,8 @@ describe('target-aware documentation consistency', () => {
     expect(guidance).toContain('--target codex');
     expect(guidance).toContain('--target claude-code');
     expect(guidance).toContain('gpt-5.6-sol');
-    expect(guidance).toContain('gpt-5.6-luna');
     expect(guidance).toContain('xhigh effort');
-    expect(guidance).toContain('max effort');
+    expect(guidance).toContain('medium effort');
   });
 
   it('links the model routing guide from operator documentation', () => {
@@ -41,11 +40,12 @@ describe('target-aware documentation consistency', () => {
     const entrypoint = read('sdd-entry.js');
 
     for (const content of [requirements, design, tasks]) {
-      expect(content).toContain('gpt-5.6-luna');
-      expect(content).toContain('max');
+      expect(content).toContain('gpt-5.6-sol');
+      expect(content).toContain('medium');
       expect(content).toContain('gpt-5.6-terra');
     }
-    expect(changelog).toContain('Luna/max');
+    expect(changelog).toContain('gpt-5.6-sol');
+    expect(changelog).toContain('medium');
     expect(changelog).not.toContain('Terra/Sonnet for implementation');
     expect(entrypoint).toContain('Install target-native components');
   });

--- a/src/__tests__/unit/cli/install-skills.test.ts
+++ b/src/__tests__/unit/cli/install-skills.test.ts
@@ -381,7 +381,7 @@ describe('InstallSkillsCLI', () => {
       expect(help).toContain('gpt-5.6-luna');
       expect(help).toContain('gpt-5.6-terra');
       expect(help).toContain('(xhigh)');
-      expect(help).toContain('(max)');
+      expect(help).toContain('(medium)');
       expect(help).toContain('opus');
       expect(help).toContain('sonnet');
     });

--- a/src/__tests__/unit/cli/install-target.test.ts
+++ b/src/__tests__/unit/cli/install-target.test.ts
@@ -25,8 +25,8 @@ describe('install target policy', () => {
     });
   });
 
-  it('uses luna as the default and sol xhigh for high-level roles', () => {
-    expect(DEFAULT_CODEX_MODEL).toBe('gpt-5.6-luna');
+  it('uses sol medium as the default and sol xhigh for high-level roles', () => {
+    expect(DEFAULT_CODEX_MODEL).toBe('gpt-5.6-sol');
     expect(ROLE_MODEL_ROUTES.planner.codex).toEqual({
       model: 'gpt-5.6-sol',
       reasoningEffort: 'xhigh',
@@ -44,12 +44,12 @@ describe('install target policy', () => {
       reasoningEffort: 'xhigh',
     });
     expect(ROLE_MODEL_ROUTES.implementer.codex).toEqual({
-      model: 'gpt-5.6-luna',
-      reasoningEffort: 'max',
+      model: 'gpt-5.6-sol',
+      reasoningEffort: 'medium',
     });
     expect(ROLE_MODEL_ROUTES['tdd-guide'].codex).toEqual({
-      model: 'gpt-5.6-luna',
-      reasoningEffort: 'max',
+      model: 'gpt-5.6-sol',
+      reasoningEffort: 'medium',
     });
     expect(ROLE_MODEL_ROUTES.reviewer.claudeCode.model).toBe('opus');
     expect(ROLE_MODEL_ROUTES['tdd-guide'].claudeCode.model).toBe('sonnet');

--- a/src/__tests__/unit/cli/target-agent-renderer.test.ts
+++ b/src/__tests__/unit/cli/target-agent-renderer.test.ts
@@ -37,11 +37,11 @@ describe('target agent rendering', () => {
     expect(rendered).toContain('\\"carefully\\"');
   });
 
-  it('renders Codex Luna max for implementation roles', () => {
+  it('renders Codex Sol medium for implementation roles', () => {
     const source = PLANNER.replaceAll('planner', 'implementer');
     const rendered = renderCodexAgent(parseSourceAgent(source));
-    expect(rendered).toContain('model = "gpt-5.6-luna"');
-    expect(rendered).toContain('model_reasoning_effort = "max"');
+    expect(rendered).toContain('model = "gpt-5.6-sol"');
+    expect(rendered).toContain('model_reasoning_effort = "medium"');
   });
 
   it('rejects an unknown role', () => {

--- a/src/__tests__/unit/cli/target-installers.test.ts
+++ b/src/__tests__/unit/cli/target-installers.test.ts
@@ -135,8 +135,8 @@ describe('target-specific installers', () => {
     expect(fs.existsSync(path.join(root, '.codex/guidance/contexts/review.md'))).toBe(true);
     expect(fs.readFileSync(path.join(root, '.codex/agents/planner.toml'), 'utf8')).toContain('model = "gpt-5.6-sol"');
     expect(fs.readFileSync(path.join(root, '.codex/agents/planner.toml'), 'utf8')).toContain('model_reasoning_effort = "xhigh"');
-    expect(fs.readFileSync(path.join(root, '.codex/agents/implementer.toml'), 'utf8')).toContain('model = "gpt-5.6-luna"');
-    expect(fs.readFileSync(path.join(root, '.codex/agents/implementer.toml'), 'utf8')).toContain('model_reasoning_effort = "max"');
+    expect(fs.readFileSync(path.join(root, '.codex/agents/implementer.toml'), 'utf8')).toContain('model = "gpt-5.6-sol"');
+    expect(fs.readFileSync(path.join(root, '.codex/agents/implementer.toml'), 'utf8')).toContain('model_reasoning_effort = "medium"');
     expect(JSON.parse(fs.readFileSync(path.join(root, '.codex/hooks.json'), 'utf8'))).toHaveProperty('hooks.SessionStart');
     expect(fs.existsSync(path.join(root, '.codex/hooks/sdd-hook-runner.mjs'))).toBe(true);
     expect(fs.readFileSync(path.join(root, 'AGENTS.md'), 'utf8')).toContain('.codex/agents/planner.toml');

--- a/src/cli/install-skills.ts
+++ b/src/cli/install-skills.ts
@@ -712,7 +712,7 @@ After installation, use skills in the selected agent:
   /sdd-test-gen [file-path]
 
 Model Routing:
-  Codex high-level roles: gpt-5.6-sol (xhigh); default implementation/TDD: gpt-5.6-luna (max)
+  Codex high-level roles: gpt-5.6-sol (xhigh); default implementation/TDD: gpt-5.6-sol (medium)
   Codex supported models: gpt-5.6-sol, gpt-5.6-luna, gpt-5.6-terra
   Claude Code high-level roles: opus; implementation/TDD: sonnet
 `;

--- a/src/cli/install-target.ts
+++ b/src/cli/install-target.ts
@@ -87,21 +87,21 @@ export const SUPPORTED_CODEX_MODELS = [
   'gpt-5.6-luna',
 ] as const;
 
-export const DEFAULT_CODEX_MODEL = 'gpt-5.6-luna' as const;
+export const DEFAULT_CODEX_MODEL = 'gpt-5.6-sol' as const;
 
 export const ROLE_MODEL_ROUTES = {
   planner: route('high-level', 'gpt-5.6-sol', 'xhigh', 'opus'),
   architect: route('high-level', 'gpt-5.6-sol', 'xhigh', 'opus'),
   reviewer: route('high-level', 'gpt-5.6-sol', 'xhigh', 'opus'),
   'security-auditor': route('high-level', 'gpt-5.6-sol', 'xhigh', 'opus'),
-  implementer: route('implementation', DEFAULT_CODEX_MODEL, 'max', 'sonnet'),
-  'tdd-guide': route('implementation', DEFAULT_CODEX_MODEL, 'max', 'sonnet'),
+  implementer: route('implementation', DEFAULT_CODEX_MODEL, 'medium', 'sonnet'),
+  'tdd-guide': route('implementation', DEFAULT_CODEX_MODEL, 'medium', 'sonnet'),
 } as const;
 
 function route(
   taskClass: 'high-level' | 'implementation',
   model: typeof SUPPORTED_CODEX_MODELS[number],
-  reasoningEffort: 'xhigh' | 'max',
+  reasoningEffort: 'xhigh' | 'medium',
   claudeModel: 'opus' | 'sonnet',
 ) {
   return {


### PR DESCRIPTION
## Summary
- Route Codex implementation and TDD specialists through `gpt-5.6-sol` with `medium` reasoning.
- Keep high-level Codex roles on `gpt-5.6-sol` with `xhigh` reasoning.
- Update role metadata, installer help, tests, documentation, and the active SDD routing records.

## Motivation
The implementation/TDD route should use Sol with medium reasoning instead of Luna with max reasoning to reduce unnecessary reasoning cost while keeping the high-level advisor route unchanged.

## Changes
- Change `DEFAULT_CODEX_MODEL` to `gpt-5.6-sol`.
- Change implementation and TDD effort from `max` to `medium`.
- Preserve Luna and Terra as supported, non-default model identifiers.
- Update native Codex rendering and installer assertions.
- Update operator documentation, model-routing guidance, changelog, and SDD specification records.

## Testing
- [x] Focused routing suites: 5 suites, 74 tests passed
- [x] Full Jest suite: 33 suites, 321 tests passed
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run lint` (0 errors; existing repository warnings remain)
- [x] `npm pack --dry-run`
- [x] `git diff --check`

## Notes
The published `3.5.0` package still contains the previous Luna/max route. This change is recorded as unreleased and should be included in the next patch release.
